### PR TITLE
feat(runtime): add adb-over-USB dev access

### DIFF
--- a/build-rootfs.sh
+++ b/build-rootfs.sh
@@ -17,7 +17,7 @@ TOOLS="$HERE/work/tools"
 
 [ -f "$WORK/source.json" ] || { echo "missing $WORK/source.json (run prepare-stock.sh $TARGET IMAGE)"; exit 1; }
 [ -f "$WORK/stock-harvest.tar" ] || { echo "missing $WORK/stock-harvest.tar (run prepare-stock.sh $TARGET IMAGE)"; exit 1; }
-for tool in busybox dropbearmulti curl fbsplash gptgrow; do
+for tool in busybox dropbearmulti curl fbsplash gptgrow adbd; do
   [ -x "$TOOLS/$tool" ] || { echo "missing $TOOLS/$tool (run build-tools.sh)"; exit 1; }
 done
 [ -f "$TOOLS/ca-certificates.crt" ] \
@@ -87,7 +87,7 @@ docker run --rm --platform linux/arm64 \
             "$R/etc/init.d/rcS" "$R/etc/init.d/rcK" "$R/etc/init.d/dev" \
             "$R/usr/bin/timedatectl" \
             "$R/usr/sbin/nextui-session" "$R/usr/sbin/systemctl" \
-            "$R/usr/sbin/expand-storage" \
+            "$R/usr/sbin/expand-storage" "$R/usr/sbin/usb-gadget-adb" \
             "$R/mnt/vendor/ctrl/setBluetooth.sh" \
             "$R/usr/share/udhcpc/default.script"
   chmod 600 "$R/etc/shadow"
@@ -95,7 +95,7 @@ docker run --rm --platform linux/arm64 \
   # skipped by its `[ -x ]` guard and fails silently — cost us one flash).
   for s in /init /etc/init.d/rcS /etc/init.d/rcK /usr/sbin/nextui-session \
            /usr/bin/timedatectl /usr/sbin/expand-storage /usr/sbin/systemctl \
-           /mnt/vendor/ctrl/setBluetooth.sh; do
+           /usr/sbin/usb-gadget-adb /mnt/vendor/ctrl/setBluetooth.sh; do
     [ -x "$R$s" ] || { echo "FATAL: $s is not executable in rootfs"; exit 1; }
   done
 
@@ -135,6 +135,10 @@ docker run --rm --platform linux/arm64 \
   mkdir -p "$R/usr/share/baseos"
   [ -f /assets/card-readme.txt ] && cp /assets/card-readme.txt "$R/usr/share/baseos/card-readme.txt"
 
+  ## 6c. adbd: adb-over-USB dev access, brought up by usb-gadget-adb (init.d/dev).
+  cp /tools/adbd "$R/usr/sbin/adbd"
+  chmod 755 "$R/usr/sbin/adbd"
+
   ## 7. ld.so.cache so the dynamic linker finds the multiarch dir
   chroot "$R" /usr/sbin/ldconfig || chroot "$R" /usr/sbin/ldconfig.real
 
@@ -151,7 +155,7 @@ docker run --rm --platform linux/arm64 \
   find "$R/usr/bin" "$R/usr/sbin" "$R/usr/libexec" -type f | while read -r f; do
     head -c4 "$f" | grep -q "^.ELF" || continue
     case "$f" in
-      */busybox|*/dropbearmulti|*/curl|*/fbsplash|*/gptgrow|*/ldconfig|*/ldconfig.real|*/rtk_hciattach) continue ;;
+      */busybox|*/dropbearmulti|*/curl|*/fbsplash|*/gptgrow|*/ldconfig|*/ldconfig.real|*/rtk_hciattach|*/adbd) continue ;;
     esac
     if ! chroot "$R" /usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1 --list \
         "${f#"$R"}" 2>/dev/null | grep -q "=>"; then

--- a/build-tools.sh
+++ b/build-tools.sh
@@ -5,6 +5,9 @@
 #   work/tools/dropbearmulti  (static dropbear + dropbearkey + dbclient + scp)
 #   work/tools/curl           (static HTTPS client used by RetroAchievements)
 #   work/tools/ca-certificates.crt (TLS trust store)
+#   work/tools/fbsplash       (framebuffer boot splash)
+#   work/tools/gptgrow        (grow last GPT partition on first boot)
+#   work/tools/adbd           (Android adb daemon, USB-only, static)
 # Runs entirely in a linux/arm64 container (native on Apple Silicon).
 set -eu
 
@@ -74,11 +77,50 @@ docker run --rm --platform linux/arm64 \
   strip /out/gptgrow
 '
 
+# adbd: Android adb daemon (android-tools 4.2.2+git20130218). Built static for
+# musl, out-of-tree via the Debian adbd makefile, exactly as Buildroot drives it
+# in package/android-tools/android-tools.mk: unpack the Debian packaging into the
+# source tree, apply the Debian quilt series, then apply the Buildroot patch
+# series plus the BaseOS-local patches (see src/adbd-patches). The result serves
+# adb over USB FunctionFS only (no network listener) and stays root.
+docker run --rm --platform linux/arm64 \
+  -v "$TOOLS":/out -v "$HERE/src/adbd-patches":/patches:ro alpine:3.20 sh -euc '
+  apk add -q build-base linux-headers pkgconf ca-certificates tar xz patch \
+    openssl-dev openssl-libs-static zlib-dev zlib-static bsd-compat-headers
+  AT_VER=4.2.2+git20130218
+  SITE=https://launchpad.net/ubuntu/+archive/primary/+files
+  ORIG_SHA256=9bfba987e1351b12aa983787b9ae4424ab752e9e646d8e93771538dc1e5d932f
+  DEB_SHA256=73c3078de3e44d8a3cadf7a360863c63155d9d558c2f0933cf38ad901a3f5998
+  cd /tmp
+  wget -q "$SITE/android-tools_$AT_VER.orig.tar.xz"
+  wget -q "$SITE/android-tools_$AT_VER-3ubuntu41.debian.tar.gz"
+  echo "$ORIG_SHA256  android-tools_$AT_VER.orig.tar.xz" | sha256sum -c -
+  echo "$DEB_SHA256  android-tools_$AT_VER-3ubuntu41.debian.tar.gz" | sha256sum -c -
+  tar xf "android-tools_$AT_VER.orig.tar.xz"
+  cd android-tools
+  tar xf "/tmp/android-tools_$AT_VER-3ubuntu41.debian.tar.gz"
+  while read -r p; do [ -z "$p" ] && continue
+    patch -g0 -p1 -E -i "debian/patches/$p" >/dev/null
+  done < debian/patches/series
+  for p in /patches/0*.patch; do patch -g0 -p1 -E -i "$p" >/dev/null; done
+  # musl carries crypt() in libc, so drop the -lcrypt the makefile assumes; link
+  # libcrypto statically. Build noise (upstream -Wall warnings) is suppressed.
+  mkdir -p build-adbd
+  make SRCDIR="$PWD" -C build-adbd -f "$PWD/debian/makefiles/adbd.mk" \
+    CC=gcc LDFLAGS=-static LIBS="-lc -lpthread -lz -lcrypto" >/dev/null 2>&1
+  strip build-adbd/adbd
+  cp build-adbd/adbd /out/adbd
+  chmod 755 /out/adbd
+'
+
 file "$TOOLS/busybox" "$TOOLS/dropbearmulti" "$TOOLS/curl" \
-  "$TOOLS/fbsplash" "$TOOLS/gptgrow" 2>/dev/null || true
+  "$TOOLS/fbsplash" "$TOOLS/gptgrow" "$TOOLS/adbd" 2>/dev/null || true
 [ -x "$TOOLS/curl" ] || { echo "curl build did not produce an executable" >&2; exit 1; }
 file "$TOOLS/curl" | grep -q "statically linked" \
   || { echo "curl build is not static" >&2; exit 1; }
 [ -s "$TOOLS/ca-certificates.crt" ] \
   || { echo "curl CA bundle is missing or empty" >&2; exit 1; }
+[ -x "$TOOLS/adbd" ] || { echo "adbd build did not produce an executable" >&2; exit 1; }
+file "$TOOLS/adbd" | grep -q "statically linked" \
+  || { echo "adbd build is not static" >&2; exit 1; }
 ls -lh "$TOOLS"

--- a/docs/01-rootfs-and-init.md
+++ b/docs/01-rootfs-and-init.md
@@ -101,8 +101,9 @@ ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100   # serial console (harmless wi
 8. mount the NextUI card: TF2 (`/dev/mmcblk1p1`) if present, else this card's own
    `/dev/mmcblk0p8` → `/mnt/sdcard`, plus the `/mnt/SDCARD` compat symlink; write a
    boot breadcrumb to the card
-9. paint `fbsplash 55`; start dev extras (`/etc/init.d/dev` → dropbear) in the
-   background
+9. paint `fbsplash 55`; start dev extras (`/etc/init.d/dev` → dropbear SSH, plus the
+   backgrounded adb-over-USB gadget via `usb-gadget-adb`, see
+   [05](05-runtime-power-network.md) §6) in the background
 
 No udev, no mdev: devtmpfs auto-creates nodes, SDL runs with
 `SDL_JOYSTICK_DISABLE_UDEV=1`, BlueZ makes its own uinput nodes, and `dbus-daemon`

--- a/docs/05-runtime-power-network.md
+++ b/docs/05-runtime-power-network.md
@@ -13,6 +13,12 @@ Kernel-relative markers are written to `/run/boot-*` by `rcS` / `nextui-session`
 | `boot-rcS-start` | 2.04 s | our init reached the first breadcrumb (proc/sys/dev/tmpfs mounted) |
 | `boot-rcS-done` | 2.59 s | modules requested, `/data` + card mounted (~0.55 s of rcS) |
 | `boot-frontend-exec` | 2.80 s | `launch.sh` handed control to NextUI |
+| `boot-dev-done` | TBD | `/etc/init.d/dev` finished starting dropbear + launching the adb gadget script |
+| `boot-adb-gadget-done` | TBD | the adb gadget bound its UDC (off the critical path — see §6) |
+
+> The `dev` / `adb-gadget` markers are **measured per release**: they sit off the
+> critical path (§6) and are re-measured, not carried forward, whenever that area
+> changes. `validate-on-device.sh` prints them on every run.
 
 Then `launch.sh` + `nextui.elf` init add ~1–2 s to the first frame. Before the kernel,
 boot0 + U-Boot add ~1.5–2.5 s (not software-visible; `bootdelay=0`).
@@ -110,3 +116,62 @@ There is no `systemd-logind` on base OS. NextUI's `keymon` reads the power key
 that `launch.sh` acts on; BusyBox init runs the poweroff/reboot. A **long-press powers
 off in hardware** at the AXP2202 PMIC regardless of software — normal, expected
 force-off behaviour.
+
+## 6. USB gadget — adb over the charge port
+
+The single USB-C port is a charge port that also exposes a USB peripheral controller.
+Base OS drives it as a Google adb gadget so a host can `adb shell`/`adb push`/`adb pull`
+over the cable — **USB only, no TCP** by design (same root/no-auth dev posture as the
+root/root dropbear; keeping it off the network avoids exposing an unauthenticated shell
+over WiFi). `/usr/sbin/usb-gadget-adb` composes the gadget; it is launched **backgrounded
+from `/etc/init.d/dev`** (itself already backgrounded off `rcS`, [01](01-rootfs-and-init.md) §5).
+
+**Role: leave the sunxi manager alone.** The port defaults to the sunxi manager's auto
+(ID-pin/VBUS) detection, and that is exactly what we rely on: the built-in UDC
+(`5100000.udc-controller`) is always present, we bind our gadget to it, and the manager
+selects peripheral mode on its own when a host cable is attached. The script does **not**
+force the role, because every way of doing so is a trap on this vendor kernel
+(measured on rg40xxv, [06](06-status-and-lessons.md) §3):
+
+- Writing `/sys/.../usbc0/otg_role` (e.g. `echo usb_device > otg_role`) **wedges the
+  writer in an uninterruptible D-state** — reproduced both with and without a gadget
+  bound — so a boot script that wrote it would leak a stuck process and never bring adb
+  up.
+- The sibling files `usb_device`/`usb_host`/`usb_null` are 0400 **read-triggers** — a
+  bare `cat` of one switches the role and can wedge the port.
+
+Leaving the role in auto mode also keeps charging on the shared USB-C port undisturbed.
+(Note the real device path is `/sys/devices/platform/soc/usbc0`, reached via the stable
+`/sys/bus/platform/devices/usbc0` symlink — but the script needs neither.)
+
+**configfs gadget layout.** The stock 4.9.170 kernel has `CONFIG_USB_CONFIGFS_F_FS=y`
+built in, so no module is needed. The script builds, under
+`/sys/kernel/config/usb_gadget/g1`:
+
+- IDs `idVendor 0x18d1` / `idProduct 0x4e42` (Google / adb);
+- `strings/0x409/serialnumber` from `androidboot.serialno` on the kernel cmdline
+  (falls back to a constant if absent), plus manufacturer/product strings;
+- one function `functions/ffs.adb`, a **FunctionFS** instance, linked into
+  `configs/c.1`;
+- the FunctionFS mount at `/dev/usb-ffs/adb`, where `adbd` opens `ep0` and writes its
+  descriptors.
+
+**Start + bind ordering.** The UDC bind is the last step and it only succeeds **after**
+`adbd` has written its descriptors to `ep0`. So the script starts `adbd` (as root)
+first, then **retries** writing the controller name into `g1/UDC`
+(`/sys/class/udc/5100000.udc-controller`) until the bind takes. Binding before `adbd`
+has populated ep0 fails with `EINVAL`; the retry loop closes that race without a fixed
+sleep.
+
+**Idempotency / suspend-resume.** The script is safe to re-run: if `g1` already exists
+and is bound it is a no-op. The gadget survives deep-sleep (§2) — the controller
+re-enumerates on resume with the descriptors still in place; nothing re-composes it.
+
+**Boot-time stance.** Nothing here is on the critical path. The gadget script is
+backgrounded off the already-backgrounded `init.d/dev`, so it never delays
+`frontend-exec`. Two measurement hooks make the cost
+observable: the script writes `/run/boot-adb-gadget-done` when the UDC bind lands and
+appends `adb gadget ready` to `/mnt/sdcard/baseos-boot.log`; `init.d/dev` writes
+`/run/boot-dev-done` when it finishes. Because these live off the critical path, the
+boot-timing table (§1) leaves them **TBD / measured per release** — re-measure and
+record them whenever this area changes rather than trusting a stale number.

--- a/docs/06-status-and-lessons.md
+++ b/docs/06-status-and-lessons.md
@@ -12,6 +12,7 @@
 | Deep sleep (real suspend-to-RAM, ~0 drain / 35 min) | ✅ |
 | WiFi unaided bring-up + stable association | ✅ (validated when the frontend's `wifi_init.sh` did the wait; the Base-OS-owned `wlan0` bring-up is not yet hardware-validated) |
 | Dropbear SSH over WiFi | ✅ |
+| adb over USB (charge port, device role) | ⏳ configfs gadget + adbd wired; not yet hardware-validated |
 | GLES video / input / audio in NextUI | ✅ (NextUI runs; port already validated these) |
 | Bluetooth audio pairing end-to-end | ⏳ daemons run; not yet paired on base OS |
 | HDMI output | ⏳ not retested on base OS |
@@ -65,6 +66,16 @@ superblock mount-counts, and `fbsplash` breadcrumbs as boot-stage forensics.
   `partprobe` (which EBUSYs). `gptgrow` does BLKPG.
 - Dropbear has no sftp-server; push with `cat | ssh 'cat > f'` (or `scp -O`), verify
   with a checksum.
+- Do **not** try to force the sunxi USB role. Writing `usbc0/otg_role` (e.g.
+  `echo usb_device > otg_role`) **wedges the writer in an uninterruptible D-state** on the
+  4.9.170 vendor kernel — reproduced both with and without a gadget bound, and only a
+  reboot clears the stuck process. Its siblings `usb_device`/`usb_host`/`usb_null` are
+  **0400 read-triggers** — merely `cat`-ing one switches the role (a `cat usb_host` wedged
+  the port). The adb gadget instead binds to the always-present UDC and lets the manager
+  auto-select peripheral mode on cable attach — no role write needed, and charging on the
+  shared port is undisturbed. (Real path is `/sys/devices/platform/soc/usbc0` via the
+  `/sys/bus/platform/devices/usbc0` symlink; the earlier `/sys/devices/platform/usbc0`
+  guess did not exist, which is how the bad `otg_role` write got masked at first.)
 - The repo shell is **fish**, which doesn't word-split variables — inline `ssh -o`
   options, never store them in a var.
 - The QEMU smoke test exercises generic userspace, not the vendor kernel or hardware.
@@ -83,8 +94,8 @@ superblock mount-counts, and `fbsplash` breadcrumbs as boot-stage forensics.
   ten supported images with per-target boot partitions, model identity and logos.
   Physical BaseOS validation beyond RG40XXV remains outstanding and must be recorded
   per model rather than inferred from successful image construction.
-- **Silence boot breadcrumbs / release vs dev image split** (serial getty + dropbear
-  are dev conveniences).
+- **Silence boot breadcrumbs / release vs dev image split** (serial getty, dropbear
+  and adb-over-USB are dev conveniences).
 - **PortMaster** later: the kernel already has squashfs + loop + overlay built in;
   glibc 2.35 and an `/etc/os-release` identity remain to be decided.
 

--- a/overlay/etc/init.d/dev
+++ b/overlay/etc/init.d/dev
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Development conveniences, started by rcS in the background.
+# Development conveniences (SSH, ADB), started by rcS in the background.
 # This file is only installed in dev-flavour images (build-rootfs.sh).
 
 # Persistent dropbear host keys on /data.
@@ -12,3 +12,10 @@ done
 # SSH daemon (password: root/root — dev images only).
 dropbear -r /data/dropbear/dropbear_rsa_host_key \
          -r /data/dropbear/dropbear_ed25519_host_key -B 2>/dev/null
+
+# adb-over-USB gadget. Safe no-op when the kernel/hardware USB bits are absent;
+# backgrounded so dropbear keygen and the gadget bring-up don't serialise.
+[ -x /usr/sbin/usb-gadget-adb ] && /usr/sbin/usb-gadget-adb &
+
+# Boot instrumentation: dev services launched.
+/bin/cut -d" " -f1 /proc/uptime > /run/boot-dev-done

--- a/overlay/usr/sbin/usb-gadget-adb
+++ b/overlay/usr/sbin/usb-gadget-adb
@@ -1,0 +1,142 @@
+#!/bin/sh
+# Bring up an adb-over-USB gadget (dev images only), started by init.d/dev.
+#
+# This is a pure developer convenience and NEVER a boot dependency: there is no
+# `set -e`, every failure path exits 0 silently, and every wait is a bounded
+# loop. If the kernel USB bits or the hardware are absent the whole thing is a
+# no-op. init.d/dev launches it backgrounded so it never serialises boot.
+#
+# CRITICAL sunxi trap (measured on rg40xxv, 4.9.170): the USB role manager's
+# role attributes must NOT be touched by this script.
+#   * Writing usbc0/otg_role (e.g. "usb_device") wedges the writer in an
+#     uninterruptible (D) kernel state forever — reproduced both with and
+#     without a gadget bound — so a boot script that wrote it would leak a
+#     stuck process every boot and never bring adb up.
+#   * The siblings usbc0/usb_device, usbc0/usb_host, usbc0/usb_null are 0400
+#     READ-triggers — merely cat-ing one switches the controller role and can
+#     wedge the port.
+# We therefore leave the manager in its default auto (ID-pin/VBUS) mode: the
+# built-in UDC is always present, we bind our gadget to it, and the manager
+# auto-selects peripheral mode when a host cable is attached. This also leaves
+# charging on the shared USB-C port undisturbed.
+
+# Env-overridable roots so the unit test can drive a fake tree on a non-Linux
+# host (see tests/test-usb-gadget-adb.sh); the same pattern timedatectl uses.
+SYS="${BASEOS_SYS_ROOT:-/sys}"
+FFS_DIR="${BASEOS_FFS_DIR:-/dev/usb-ffs/adb}"
+
+UDC_DIR="$SYS/class/udc"
+CONFIGFS="$SYS/kernel/config"
+GADGET="$CONFIGFS/usb_gadget/g1"
+
+# Test hook: when BASEOS_SYS_ROOT is set we are running against a fake tree, not
+# real hardware, so skip the configfs/functionfs mounts, pidof and adbd launch —
+# the writes into the fake gadget tree are what the test asserts. Never set
+# on-device, where these steps are all required.
+if [ -n "${BASEOS_SYS_ROOT:-}" ]; then
+	TEST_MODE=1
+else
+	TEST_MODE=
+fi
+
+# 1. Idempotent re-entry (suspend/resume, manual re-run): a gadget that is
+#    already bound to a UDC is left completely alone.
+if [ -d "$GADGET" ] && [ -s "$GADGET/UDC" ]; then
+	exit 0
+fi
+
+# 2. Wait up to ~5s for a UDC to appear. None => no USB device controller on
+#    this kernel/board; a silent no-op is the correct behaviour. (We do NOT
+#    force the role — see the trap above; the UDC is present regardless.)
+udc=
+n=0
+while [ "$n" -lt 20 ]; do
+	for u in "$UDC_DIR"/*; do
+		[ -e "$u" ] || continue
+		udc="${u##*/}"
+		break
+	done
+	[ -n "$udc" ] && break
+	sleep 0.25 2>/dev/null || sleep 1
+	n=$((n + 1))
+done
+[ -n "$udc" ] || exit 0
+
+# 3. configfs carries the gadget tree. Mount it if the kernel hasn't; bail if
+#    this kernel lacks CONFIGFS_F_FS (no usb_gadget dir).
+if [ -z "$TEST_MODE" ]; then
+	if ! grep -q " $CONFIGFS configfs " /proc/mounts 2>/dev/null; then
+		mount -t configfs none "$CONFIGFS" 2>/dev/null
+	fi
+fi
+[ -d "$CONFIGFS/usb_gadget" ] || exit 0
+
+# 4. Compose gadget g1. mkdir -p is safe on configfs (returns 0 on an existing
+#    node) so re-runs before a bind just re-assert the same values.
+mkdir -p "$GADGET" 2>/dev/null || exit 0
+# Android's host-side adb matches its interface by class/subclass/protocol
+# (ff/42/01), NOT by these ids — they are the conventional Android VID/PID and
+# only need to be present and consistent.
+echo 0x18d1 > "$GADGET/idVendor" 2>/dev/null
+echo 0x4e42 > "$GADGET/idProduct" 2>/dev/null
+
+# Serial: prefer the bootloader's androidboot.serialno, then the machine-id,
+# then a constant — it only has to be a stable non-empty string.
+serial=
+for w in $(cat /proc/cmdline 2>/dev/null); do
+	case "$w" in
+		androidboot.serialno=*) serial="${w#androidboot.serialno=}" ;;
+	esac
+done
+[ -n "$serial" ] || { [ -s /run/machine-id ] && IFS= read -r serial < /run/machine-id; }
+[ -n "$serial" ] || serial=baseos
+
+# Product string = the device model from /etc/baseos-release (build-rootfs bakes
+# BASEOS_MODEL there); fall back to a constant.
+BASEOS_MODEL=BaseOS
+[ -r /etc/baseos-release ] && . /etc/baseos-release 2>/dev/null
+model="${BASEOS_MODEL:-BaseOS}"
+
+mkdir -p "$GADGET/strings/0x409" 2>/dev/null
+echo "$serial" > "$GADGET/strings/0x409/serialnumber" 2>/dev/null
+echo BaseOS     > "$GADGET/strings/0x409/manufacturer" 2>/dev/null
+echo "$model"   > "$GADGET/strings/0x409/product" 2>/dev/null
+
+mkdir -p "$GADGET/functions/ffs.adb" 2>/dev/null
+mkdir -p "$GADGET/configs/c.1/strings/0x409" 2>/dev/null
+echo adb > "$GADGET/configs/c.1/strings/0x409/configuration" 2>/dev/null
+[ -e "$GADGET/configs/c.1/ffs.adb" ] \
+	|| ln -s "$GADGET/functions/ffs.adb" "$GADGET/configs/c.1/ffs.adb" 2>/dev/null
+
+# 5. functionfs endpoint + the daemon that services it.
+mkdir -p "$FFS_DIR" 2>/dev/null
+if [ -z "$TEST_MODE" ]; then
+	if ! grep -q " $FFS_DIR functionfs " /proc/mounts 2>/dev/null; then
+		mount -t functionfs adb "$FFS_DIR" 2>/dev/null
+	fi
+	pidof adbd >/dev/null 2>&1 || /usr/sbin/adbd >/dev/null 2>&1 &
+fi
+
+# 6. Bind: the UDC only accepts the gadget once adbd has written the function's
+#    descriptors to ep0 of the functionfs mount, so the first writes fail with
+#    -EINVAL. Retry for up to ~10s; a timeout is still a silent no-op.
+bound=
+n=0
+while [ "$n" -lt 40 ]; do
+	if echo "$udc" > "$GADGET/UDC" 2>/dev/null && [ -s "$GADGET/UDC" ]; then
+		bound=1
+		break
+	fi
+	sleep 0.25 2>/dev/null || sleep 1
+	n=$((n + 1))
+done
+[ -n "$bound" ] || exit 0
+
+# 7. Boot-time breadcrumbs (repo convention, cf. rcS): fast boot is a headline
+#    feature, and these stamps are how a regression gets spotted.
+{ cut -d" " -f1 /proc/uptime > /run/boot-adb-gadget-done; } 2>/dev/null || true
+if mountpoint -q /mnt/sdcard 2>/dev/null; then
+	{ echo "$(cut -d' ' -f1 /proc/uptime) adb gadget ready" >> /mnt/sdcard/baseos-boot.log; } 2>/dev/null || true
+fi
+
+exit 0

--- a/src/adbd-patches/0001-Fix-makefiles-for-out-of-tree-build.patch
+++ b/src/adbd-patches/0001-Fix-makefiles-for-out-of-tree-build.patch
@@ -1,0 +1,165 @@
+From 1fe49c34aa3e32e801af5c56293ec71ff6e7e2bc Mon Sep 17 00:00:00 2001
+From: Gary Bisson <gary.bisson@boundarydevices.com>
+Date: Sun, 1 Dec 2024 15:43:17 +0100
+Subject: [PATCH] Fix makefiles for out-of-tree build
+
+Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>
+---
+ debian/makefiles/adb.mk      | 10 +++++-----
+ debian/makefiles/adbd.mk     | 33 ++++++++++++++++-----------------
+ debian/makefiles/fastboot.mk | 17 +++++++++--------
+ 3 files changed, 30 insertions(+), 30 deletions(-)
+
+diff --git a/debian/makefiles/adb.mk b/debian/makefiles/adb.mk
+index d9d4feb..654b9f1 100644
+--- a/debian/makefiles/adb.mk
++++ b/debian/makefiles/adb.mk
+@@ -1,5 +1,6 @@
+ # Makefile for adb; from https://heiher.info/2227.html
+ 
++VPATH+= $(SRCDIR)/core/adb
+ SRCS+= adb.c
+ SRCS+= adb_client.c
+ SRCS+= adb_auth_host.c
+@@ -17,7 +18,7 @@ SRCS+= usb_linux.c
+ SRCS+= usb_vendors.c
+ SRCS+= utils.c
+ 
+-VPATH+= ../libcutils
++VPATH+= $(SRCDIR)/core/libcutils
+ SRCS+= abort_socket.c
+ SRCS+= socket_inaddr_any_server.c
+ SRCS+= socket_local_client.c
+@@ -28,7 +29,7 @@ SRCS+= socket_network_client.c
+ SRCS+= list.c
+ SRCS+= load_file.c
+ 
+-VPATH+= ../libzipfile
++VPATH+= $(SRCDIR)/core/libzipfile
+ SRCS+= centraldir.c
+ SRCS+= zipfile.c
+ 
+@@ -37,9 +38,8 @@ CPPFLAGS+= -DADB_HOST=1
+ CPPFLAGS+= -DHAVE_FORKEXEC=1
+ CPPFLAGS+= -DHAVE_SYMLINKS
+ CPPFLAGS+= -DHAVE_TERMIO_H
+-CPPFLAGS+= -I.
+-CPPFLAGS+= -I../include
+-CPPFLAGS+= -I../../../external/zlib
++CPPFLAGS+= -I$(SRCDIR)/core/adb
++CPPFLAGS+= -I$(SRCDIR)/core/include
+ 
+ LIBS+= -lc -lpthread -lz -lcrypto
+ 
+diff --git a/debian/makefiles/adbd.mk b/debian/makefiles/adbd.mk
+index 94d3a90..49dab8c 100644
+--- a/debian/makefiles/adbd.mk
++++ b/debian/makefiles/adbd.mk
+@@ -1,18 +1,6 @@
+ # Makefile for adbd
+ 
+-VPATH+= ../libcutils
+-SRCS+= abort_socket.c
+-SRCS+= socket_inaddr_any_server.c
+-SRCS+= socket_local_client.c
+-SRCS+= socket_local_server.c
+-SRCS+= socket_loopback_client.c
+-SRCS+= socket_loopback_server.c
+-SRCS+= socket_network_client.c
+-SRCS+= list.c
+-SRCS+= load_file.c
+-SRCS+= android_reboot.c
+-
+-#VPATH+= ../adb
++VPATH+= $(SRCDIR)/core/adbd
+ SRCS+=  adb.c
+ SRCS+=	backup_service.c
+ SRCS+=	fdevent.c
+@@ -31,7 +19,19 @@ SRCS+=	log_service.c
+ SRCS+=	utils.c
+ SRCS+=	base64.c
+ 
+-VPATH+= ../libzipfile
++VPATH+= $(SRCDIR)/core/libcutils
++SRCS+= abort_socket.c
++SRCS+= socket_inaddr_any_server.c
++SRCS+= socket_local_client.c
++SRCS+= socket_local_server.c
++SRCS+= socket_loopback_client.c
++SRCS+= socket_loopback_server.c
++SRCS+= socket_network_client.c
++SRCS+= list.c
++SRCS+= load_file.c
++SRCS+= android_reboot.c
++
++VPATH+= $(SRCDIR)/core/libzipfile
+ SRCS+= centraldir.c
+ SRCS+= zipfile.c
+ 
+@@ -40,10 +40,9 @@ CPPFLAGS+= -O2 -g -Wall -Wno-unused-parameter
+ CPPFLAGS+= -DADB_HOST=0 -DHAVE_FORKEXEC=1 -D_XOPEN_SOURCE -D_GNU_SOURCE -DALLOW_ADBD_ROOT=1
+ CPPFLAGS+= -DHAVE_SYMLINKS -DBOARD_ALWAYS_INSECURE
+ CPPFLAGS+= -DHAVE_TERMIO_H
+-CPPFLAGS+= -I.
+-CPPFLAGS+= -I../include
+-CPPFLAGS+= -I../../../external/zlib
+ CPPFLAGS+= `pkg-config --cflags glib-2.0 gio-2.0`
++CPPFLAGS+= -I$(SRCDIR)/core/adbd
++CPPFLAGS+= -I$(SRCDIR)/core/include
+ 
+ LIBS+= -lc -lpthread -lz -lcrypto -lcrypt `pkg-config --libs glib-2.0 gio-2.0`
+ 
+diff --git a/debian/makefiles/fastboot.mk b/debian/makefiles/fastboot.mk
+index 9e8b751..94a069b 100644
+--- a/debian/makefiles/fastboot.mk
++++ b/debian/makefiles/fastboot.mk
+@@ -1,5 +1,6 @@
+ # Makefile for fastboot; from https://heiher.info/2227.html
+ 
++VPATH+= $(SRCDIR)/core/fastboot
+ SRCS+= bootimg.c
+ SRCS+= engine.c
+ SRCS+= fastboot.c
+@@ -7,11 +8,11 @@ SRCS+= protocol.c
+ SRCS+= usb_linux.c
+ SRCS+= util_linux.c
+ 
+-VPATH+= ../libzipfile
++VPATH+= $(SRCDIR)/core/libzipfile
+ SRCS+= centraldir.c
+ SRCS+= zipfile.c
+ 
+-VPATH+= ../libsparse
++VPATH+= $(SRCDIR)/core/libsparse
+ SRCS+= backed_block.c
+ SRCS+= sparse_crc32.c
+ SRCS+= sparse.c
+@@ -19,7 +20,7 @@ SRCS+= sparse_read.c
+ SRCS+= sparse_err.c
+ SRCS+= output_file.c
+ 
+-VPATH+= ../../extras/ext4_utils/
++VPATH+= $(SRCDIR)/extras/ext4_utils/
+ SRCS+= make_ext4fs.c
+ SRCS+= crc16.c
+ SRCS+= ext4_utils.c
+@@ -31,11 +32,11 @@ SRCS+= extent.c
+ SRCS+= wipe.c
+ SRCS+= sha1.c
+ 
+-CPPFLAGS+= -I.
+-CPPFLAGS+= -I../include
+-CPPFLAGS+= -I../mkbootimg
+-CPPFLAGS+= -I../../extras/ext4_utils/
+-CPPFLAGS+= -I../libsparse/include/
++CPPFLAGS+= -I$(SRCDIR)/core/fastboot
++CPPFLAGS+= -I$(SRCDIR)/core/include
++CPPFLAGS+= -I$(SRCDIR)/core/mkbootimg
++CPPFLAGS+= -I$(SRCDIR)/extras/ext4_utils/
++CPPFLAGS+= -I$(SRCDIR)/core/libsparse/include/
+ 
+ LIBS+= -lz -lselinux
+ 
+-- 
+2.47.0
+

--- a/src/adbd-patches/0002-Fix-adbd-for-non-Ubuntu-systems.patch
+++ b/src/adbd-patches/0002-Fix-adbd-for-non-Ubuntu-systems.patch
@@ -1,0 +1,267 @@
+From d433d5c340f3b36de58ea8550fd140dbdaea13b4 Mon Sep 17 00:00:00 2001
+From: Gary Bisson <gary.bisson@boundarydevices.com>
+Date: Sun, 1 Dec 2024 15:43:33 +0100
+Subject: [PATCH] Fix adbd for non-Ubuntu systems
+
+Remove glib/dbus dependencies and partially restore services.c to be
+closer to the original source code in order to run on systems without
+sudo.
+
+Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>
+---
+ core/adbd/adb.c          |   1 -
+ core/adbd/services.c     | 160 +++------------------------------------
+ debian/makefiles/adbd.mk |   4 +-
+ 3 files changed, 14 insertions(+), 151 deletions(-)
+
+diff --git a/core/adbd/adb.c b/core/adbd/adb.c
+index d90e6b8..7fe6445 100644
+--- a/core/adbd/adb.c
++++ b/core/adbd/adb.c
+@@ -1165,7 +1165,6 @@ void build_local_name(char* target_str, size_t target_size, int server_port)
+ 
+ #if !ADB_HOST
+ static int should_drop_privileges() {
+-    return 1;
+ #ifndef ALLOW_ADBD_ROOT
+     return 1;
+ #else /* ALLOW_ADBD_ROOT */
+diff --git a/core/adbd/services.c b/core/adbd/services.c
+index 05bd0d0..5adcefe 100644
+--- a/core/adbd/services.c
++++ b/core/adbd/services.c
+@@ -20,15 +20,6 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <pwd.h>
+-#include <glib.h>
+-#include <gio/gio.h>
+-
+-#define UNITY_SERVICE "com.canonical.UnityGreeter"
+-#define GREETER_OBJ "/"
+-#define GREETER_INTERFACE "com.canonical.UnityGreeter"
+-#define PROPERTIES_INTERFACE "org.freedesktop.DBus.Properties"
+-#define ACTIVE_PROPERTY "IsActive"
+-#define UNLOCK_PATH "/userdata/.adb_onlock"
+ 
+ #include "sysdeps.h"
+ 
+@@ -268,11 +259,11 @@ static int create_service_thread(void (*func)(int, void *), void *cookie)
+ }
+ 
+ #if !ADB_HOST
+-static int create_subprocess(const char *cmd, const char *arg0, const char *arg1, const char *arg2, const char *arg3,  const char *arg4, pid_t *pid)
++static int create_subprocess(const char *cmd, const char *arg0, const char *arg1, pid_t *pid)
+ {
+ #ifdef HAVE_WIN32_PROC
+-    D("create_subprocess(cmd=%s, arg0=%s, arg1=%s, arg2=%s, arg3=%, arg4=%ss)\n", cmd, arg0, arg1, arg2, arg3, arg4);
+-    fprintf(stderr, "error: create_subprocess not implemented on Win32 (%s %s %s %s %s %s)\n", cmd, arg0, arg1, arg2, arg3, arg4);
++    D("create_subprocess(cmd=%s, arg0=%s, arg1=%s)\n", cmd, arg0, arg1);
++    fprintf(stderr, "error: create_subprocess not implemented on Win32 (%s %s %s)\n", cmd, arg0, arg1);
+     return -1;
+ #else /* !HAVE_WIN32_PROC */
+     char *devname;
+@@ -327,7 +318,7 @@ static int create_subprocess(const char *cmd, const char *arg0, const char *arg1
+         } else {
+            D("adb: unable to open %s\n", text);
+         }
+-	execl(cmd, cmd, arg0, arg1, arg2, arg3, arg4, NULL);
++        execl(cmd, cmd, arg0, arg1, NULL);
+         fprintf(stderr, "- exec '%s' failed: %s (%d) -\n",
+                 cmd, strerror(errno), errno);
+         exit(-1);
+@@ -342,7 +333,7 @@ static int create_subprocess(const char *cmd, const char *arg0, const char *arg1
+ }
+ #endif  /* !ABD_HOST */
+ 
+-#if ADB_HOST
++#if ADB_HOST || ADBD_NON_ANDROID
+ #define SHELL_COMMAND "/bin/sh"
+ #else
+ #define SHELL_COMMAND "/system/bin/sh"
+@@ -380,139 +371,16 @@ static void subproc_waiter_service(int fd, void *cookie)
+     }
+ }
+ 
+-int is_phone_locked() {
+-    GError *error = NULL;
+-    GVariant *variant = NULL;
+-    GDBusConnection *connection = NULL;
+-
+-    if (g_file_test(UNLOCK_PATH, G_FILE_TEST_EXISTS)) {
+-        D("unlock path present.");
+-        return 0;
+-    }
+-
+-    // check if the environment variable is present, if not we grab it from
+-    // the phablet user
+-    if (g_getenv("DBUS_SESSION_BUS_ADDRESS") == NULL) {
+-        D("DBUS_SESSION_BUS_ADDRESS missing.\n");
+-        struct passwd *pw = getpwuid(AID_SHELL);
+-        char user_id[15];
+-        gchar *path = NULL;
+-        gchar *contents = NULL;
+-        gchar *session_path = NULL;
+-
+-        snprintf(user_id, sizeof user_id, "%d", pw->pw_uid);
+-
+-        path = g_build_filename("/run", "user", user_id, "dbus-session", NULL);
+-
+-        g_file_get_contents(path, &contents, NULL, &error);
+-        session_path = g_strstrip(g_strsplit(contents, "DBUS_SESSION_BUS_ADDRESS=", -1)[1]);
+-        D("Session bus is %s\n", session_path);
+-
+-        // path is not longer used
+-        g_free(path);
+-
+-        if (error != NULL) {
+-            g_clear_error(&error);
+-            D("Couldn't set session bus\n");
+-            return 1;
+-        }
+-
+-        g_setenv("DBUS_SESSION_BUS_ADDRESS", session_path, TRUE);
+-        g_free(contents);
+-    }
+-
+-    // set the uid to be able to connect to the phablet user session bus
+-    setuid(AID_SHELL);
+-    connection =  g_dbus_connection_new_for_address_sync(g_getenv("DBUS_SESSION_BUS_ADDRESS"),
+-                                                         G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT | G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION,
+-                                                         NULL,
+-                                                         NULL,
+-                                                         &error);
+-    if (connection == NULL) {
+-        D("session bus not available: %s", error->message);
+-        g_error_free (error);
+-        return 1;
+-    }
+-
+-    variant = g_dbus_connection_call_sync(connection,
+-                                          UNITY_SERVICE,
+-                                          GREETER_OBJ,
+-                                          PROPERTIES_INTERFACE,
+-                                          "Get",
+-                                          g_variant_new("(ss)", GREETER_INTERFACE, ACTIVE_PROPERTY),
+-                                          g_variant_type_new("(v)"),
+-                                          G_DBUS_CALL_FLAGS_NONE,
+-                                          -1,
+-                                          NULL,
+-                                          &error);
+-
+-    if (error != NULL) {
+-        D("Could not get property: %s", error->message);
+-        g_object_unref(connection);
+-        g_error_free(error);
+-        return 1;
+-    }
+-
+-    if (variant == NULL) {
+-        D("Failed to get property '%s': %s", "IsActive", error->message);
+-        g_object_unref(connection);
+-        g_error_free(error);
+-        return 1;
+-    }
+-
+-    variant = g_variant_get_variant(g_variant_get_child_value(variant, 0));
+-
+-    int active = 1;
+-    if (!g_variant_get_boolean(variant)) {
+-        active = 0;
+-    }
+-
+-    // get back to be root and return the value
+-    g_object_unref(connection);
+-    g_variant_unref(variant);
+-    setuid(0);
+-    return active;
+-}
+-
+ static int create_subproc_thread(const char *name)
+ {
+-    if (is_phone_locked() ) {
+-        fprintf(stderr, "device is locked\n");
+-        return -1;
+-    }
+-
+     stinfo *sti;
+     adb_thread_t t;
+     int ret_fd;
+     pid_t pid;
+-
+-    struct passwd *user = getpwuid(getuid());
+-    char *shell;
+-    char *shellopts = "-c";
+-    char *home;
+-    char *sudo = "/usr/bin/sudo";
+-    char useropt[256] = "-u";
+-
+-    if (user->pw_name)
+-        strcat(useropt, user->pw_name);
+-
+-    if (user && user->pw_shell) {
+-        shell = user->pw_shell;
+-        shellopts = "-cl";
+-    } else {
+-        shell = SHELL_COMMAND;
+-    }
+-
+-    if (user->pw_dir)
+-        home = user->pw_dir;
+-        if(chdir(home) < 0 )
+-            return 1;
+-
+     if(name) {
+-	ret_fd = create_subprocess(sudo, useropt, "-i", shell, shellopts, name, &pid);
++        ret_fd = create_subprocess(SHELL_COMMAND, "-c", name, &pid);
+     } else {
+-	shellopts = "-l";
+-	ret_fd = create_subprocess(sudo, useropt, "-i", shell, shellopts, 0, &pid);
++        ret_fd = create_subprocess(SHELL_COMMAND, "-", 0, &pid);
+     }
+     D("create_subprocess() ret_fd=%d pid=%d\n", ret_fd, pid);
+ 
+@@ -585,17 +453,13 @@ int service_to_fd(const char *name)
+     } else if (!strncmp(name, "log:", 4)) {
+         ret = create_service_thread(log_service, get_log_file_path(name + 4));
+     } else if(!HOST && !strncmp(name, "shell:", 6)) {
+-        if (!is_phone_locked() ) {
+-            if(name[6]) {
+-                ret = create_subproc_thread(name + 6);
+-            } else {
+-                ret = create_subproc_thread(0);
+-            }
++        if(name[6]) {
++            ret = create_subproc_thread(name + 6);
++        } else {
++            ret = create_subproc_thread(0);
+         }
+     } else if(!strncmp(name, "sync:", 5)) {
+-        if (!is_phone_locked() ) {
+-            ret = create_service_thread(file_sync_service, NULL);
+-        }
++        ret = create_service_thread(file_sync_service, NULL);
+     } else if(!strncmp(name, "remount:", 8)) {
+         ret = create_service_thread(remount_service, NULL);
+     } else if(!strncmp(name, "reboot:", 7)) {
+diff --git a/debian/makefiles/adbd.mk b/debian/makefiles/adbd.mk
+index 49dab8c..22c1816 100644
+--- a/debian/makefiles/adbd.mk
++++ b/debian/makefiles/adbd.mk
+@@ -40,11 +40,11 @@ CPPFLAGS+= -O2 -g -Wall -Wno-unused-parameter
+ CPPFLAGS+= -DADB_HOST=0 -DHAVE_FORKEXEC=1 -D_XOPEN_SOURCE -D_GNU_SOURCE -DALLOW_ADBD_ROOT=1
+ CPPFLAGS+= -DHAVE_SYMLINKS -DBOARD_ALWAYS_INSECURE
+ CPPFLAGS+= -DHAVE_TERMIO_H
+-CPPFLAGS+= `pkg-config --cflags glib-2.0 gio-2.0`
++CPPFLAGS+= -DADBD_NON_ANDROID
+ CPPFLAGS+= -I$(SRCDIR)/core/adbd
+ CPPFLAGS+= -I$(SRCDIR)/core/include
+ 
+-LIBS+= -lc -lpthread -lz -lcrypto -lcrypt `pkg-config --libs glib-2.0 gio-2.0`
++LIBS+= -lc -lpthread -lz -lcrypto -lcrypt
+ 
+ OBJS= $(patsubst %, %.o, $(basename $(SRCS)))
+ 
+-- 
+2.47.0
+

--- a/src/adbd-patches/0003-Adjust-base64-function-handling.patch
+++ b/src/adbd-patches/0003-Adjust-base64-function-handling.patch
@@ -1,0 +1,96 @@
+From 946dbb00fe4b2a75c688a470fc0c3924aa018a24 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Sun, 14 Jul 2024 11:39:49 +0200
+Subject: [PATCH] Adjust base64 function handling
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In order to support libcs that do not provide b64_pton(), one of the
+Debian patches adds a copy of b64_pton() and b64_ntop(). However, no
+prototype is added for those functions, causing an "implicit
+declaration" warning... or error depending on the compiler version
+used:
+
+core/adbd/adb_auth_client.c:75:15: error: implicit declaration of function ‘b64_pton’ [-Wimplicit-function-declaration]
+
+This patch adds appropriate prototypes, but while at it, also renames
+the internal copy of b64_*() functions to have an adb_ prefix in order
+to clarify things and not clash with definitions potentially coming
+from the C library.
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ core/adb/adb_auth_client.c  | 3 ++-
+ core/adbd/adb_auth_client.c | 3 ++-
+ core/adbd/base64.c          | 4 ++--
+ 3 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/core/adb/adb_auth_client.c b/core/adb/adb_auth_client.c
+index 0b4913e..25b9828 100644
+--- a/core/adb/adb_auth_client.c
++++ b/core/adb/adb_auth_client.c
+@@ -45,6 +45,7 @@ static char *key_paths[] = {
+ static fdevent listener_fde;
+ static int framework_fd = -1;
+ 
++extern int adb_b64_pton(char const *src, u_char *target, size_t targsize);
+ 
+ static void read_keys(const char *file, struct listnode *list)
+ {
+@@ -72,7 +73,7 @@ static void read_keys(const char *file, struct listnode *list)
+         if (sep)
+             *sep = '\0';
+ 
+-        ret = __b64_pton(buf, (u_char *)&key->key, sizeof(key->key) + 4);
++        ret = adb_b64_pton(buf, (u_char *)&key->key, sizeof(key->key) + 4);
+         if (ret != sizeof(key->key)) {
+             D("%s: Invalid base64 data ret=%d\n", file, ret);
+             free(key);
+diff --git a/core/adbd/adb_auth_client.c b/core/adbd/adb_auth_client.c
+index 0b4913e..25b9828 100644
+--- a/core/adbd/adb_auth_client.c
++++ b/core/adbd/adb_auth_client.c
+@@ -45,6 +45,7 @@ static char *key_paths[] = {
+ static fdevent listener_fde;
+ static int framework_fd = -1;
+ 
++extern int adb_b64_pton(char const *src, u_char *target, size_t targsize);
+ 
+ static void read_keys(const char *file, struct listnode *list)
+ {
+@@ -72,7 +73,7 @@ static void read_keys(const char *file, struct listnode *list)
+         if (sep)
+             *sep = '\0';
+ 
+-        ret = __b64_pton(buf, (u_char *)&key->key, sizeof(key->key) + 4);
++        ret = adb_b64_pton(buf, (u_char *)&key->key, sizeof(key->key) + 4);
+         if (ret != sizeof(key->key)) {
+             D("%s: Invalid base64 data ret=%d\n", file, ret);
+             free(key);
+diff --git a/core/adbd/base64.c b/core/adbd/base64.c
+index 7270703..91fc1b2 100644
+--- a/core/adbd/base64.c
++++ b/core/adbd/base64.c
+@@ -134,7 +134,7 @@ static const char Pad64 = '=';
+    */
+ 
+ int
+-b64_ntop(src, srclength, target, targsize)
++adb_b64_ntop(src, srclength, target, targsize)
+ 	u_char const *src;
+ 	size_t srclength;
+ 	char *target;
+@@ -212,7 +212,7 @@ b64_ntop(src, srclength, target, targsize)
+  */
+ 
+ int
+-b64_pton(src, target, targsize)
++adb_b64_pton(src, target, targsize)
+ 	char const *src;
+ 	u_char *target;
+ 	size_t targsize;
+-- 
+2.47.0
+

--- a/src/adbd-patches/0004-Fix-build-issue-with-musl.patch
+++ b/src/adbd-patches/0004-Fix-build-issue-with-musl.patch
@@ -1,0 +1,51 @@
+From d14ca3e3362448590adaebacb76d4d8046f9b556 Mon Sep 17 00:00:00 2001
+From: Gary Bisson <gary.bisson@boundarydevices.com>
+Date: Sun, 1 Dec 2024 15:44:16 +0100
+Subject: [PATCH] Fix build issue with musl
+
+arpa/nameser.h doesn't use the same macro name to avoid several
+inclusions.
+
+Finally had an issue with framebuffer_service.c since it was missing the
+TEMP_FAILURE_RETRY macro.
+
+Signed-off-by: Gary Bisson <gary.bisson@boundarydevices.com>
+---
+ core/adbd/arpa_nameser.h        | 3 +++
+ core/adbd/framebuffer_service.c | 1 +
+ 2 files changed, 4 insertions(+)
+
+diff --git a/core/adbd/arpa_nameser.h b/core/adbd/arpa_nameser.h
+index 438dc04..f3d2fee 100644
+--- a/core/adbd/arpa_nameser.h
++++ b/core/adbd/arpa_nameser.h
+@@ -52,6 +52,8 @@
+ 
+ #ifndef _ARPA_NAMESER_H_
+ #define _ARPA_NAMESER_H_
++#ifndef _ARPA_NAMESER_H
++#define _ARPA_NAMESER_H
+ 
+ #define BIND_4_COMPAT
+ 
+@@ -574,4 +576,5 @@ __END_DECLS
+ #define  XLOG(...)   do {} while (0)
+ #endif
+ 
++#endif /* !_ARPA_NAMESER_H */
+ #endif /* !_ARPA_NAMESER_H_ */
+diff --git a/core/adbd/framebuffer_service.c b/core/adbd/framebuffer_service.c
+index 20c08d2..48e0241 100644
+--- a/core/adbd/framebuffer_service.c
++++ b/core/adbd/framebuffer_service.c
+@@ -26,6 +26,7 @@
+ #include "fdevent.h"
+ #include "adb.h"
+ 
++#include <cutils/fs.h>
+ #include <linux/fb.h>
+ #include <sys/ioctl.h>
+ #include <sys/mman.h>
+-- 
+2.47.0
+

--- a/src/adbd-patches/0005-makefiles-use-pkgconf-to-get-libs-deps.patch
+++ b/src/adbd-patches/0005-makefiles-use-pkgconf-to-get-libs-deps.patch
@@ -1,0 +1,48 @@
+From 10f3f6fb75da72f155e72794d6647e4fa21a87d0 Mon Sep 17 00:00:00 2001
+From: Giulio Benetti <giulio.benetti@micronovasrl.com>
+Date: Sun, 1 Dec 2024 15:45:01 +0100
+Subject: [PATCH] makefiles: use pkgconf to get libs deps
+
+LIBS lists library dependencies without taking into account static linking
+that need ordered listing and more libraries listed since differently from
+shared linking dependency is not transparent(i.e. -lcrypto could need
+-latomic etc.).
+
+Replace -lcrypto with `pkg-config --libs libcrypto` command to be sure all
+needed libraries are listed during linking.
+
+Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>
+---
+ debian/makefiles/adb.mk  | 2 +-
+ debian/makefiles/adbd.mk | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/debian/makefiles/adb.mk b/debian/makefiles/adb.mk
+index 654b9f1..a03c93a 100644
+--- a/debian/makefiles/adb.mk
++++ b/debian/makefiles/adb.mk
+@@ -41,7 +41,7 @@ CPPFLAGS+= -DHAVE_TERMIO_H
+ CPPFLAGS+= -I$(SRCDIR)/core/adb
+ CPPFLAGS+= -I$(SRCDIR)/core/include
+ 
+-LIBS+= -lc -lpthread -lz -lcrypto
++LIBS+= -lc -lpthread -lz `pkg-config --libs libcrypto`
+ 
+ OBJS= $(SRCS:.c=.o)
+ 
+diff --git a/debian/makefiles/adbd.mk b/debian/makefiles/adbd.mk
+index 22c1816..a8eee3a 100644
+--- a/debian/makefiles/adbd.mk
++++ b/debian/makefiles/adbd.mk
+@@ -44,7 +44,7 @@ CPPFLAGS+= -DADBD_NON_ANDROID
+ CPPFLAGS+= -I$(SRCDIR)/core/adbd
+ CPPFLAGS+= -I$(SRCDIR)/core/include
+ 
+-LIBS+= -lc -lpthread -lz -lcrypto -lcrypt
++LIBS+= -lc -lpthread -lz `pkg-config --libs libcrypto` -lcrypt
+ 
+ OBJS= $(patsubst %, %.o, $(basename $(SRCS)))
+ 
+-- 
+2.47.0
+

--- a/src/adbd-patches/0006-Fix-build-on-big-endian-systems.patch
+++ b/src/adbd-patches/0006-Fix-build-on-big-endian-systems.patch
@@ -1,0 +1,71 @@
+From 8f7e9458dbfca969d3edc9cf409b3439e98f4c5a Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+Date: Sun, 1 Dec 2024 15:45:26 +0100
+Subject: [PATCH] Fix build on big endian systems
+
+The usb_linux_client.c file defines cpu_to_le16/32 by using the C
+library htole16/32 function calls. However, cpu_to_le16/32 are used
+when initializing structures, i.e in a context where a function call
+is not allowed.
+
+It works fine on little endian systems because htole16/32 are defined
+by the C library as no-ops. But on big-endian systems, they are
+actually doing something, which might involve calling a function,
+causing build failures.
+
+To solve this, we simply open-code cpu_to_le16/32 in a way that allows
+them to be used when initializing structures.
+
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
+---
+ core/adb/usb_linux_client.c  | 11 +++++++++--
+ core/adbd/usb_linux_client.c | 11 +++++++++--
+ 2 files changed, 18 insertions(+), 4 deletions(-)
+
+diff --git a/core/adb/usb_linux_client.c b/core/adb/usb_linux_client.c
+index fb1dad0..a981e96 100644
+--- a/core/adb/usb_linux_client.c
++++ b/core/adb/usb_linux_client.c
+@@ -34,8 +34,15 @@
+ #define MAX_PACKET_SIZE_FS	64
+ #define MAX_PACKET_SIZE_HS	512
+ 
+-#define cpu_to_le16(x)  htole16(x)
+-#define cpu_to_le32(x)  htole32(x)
++#if __BYTE_ORDER == __LITTLE_ENDIAN
++# define cpu_to_le16(x) (x)
++# define cpu_to_le32(x) (x)
++#else
++# define cpu_to_le16(x) ((((x) >> 8) & 0xffu) | (((x) & 0xffu) << 8))
++# define cpu_to_le32(x) \
++	((((x) & 0xff000000u) >> 24) | (((x) & 0x00ff0000u) >>  8) | \
++	 (((x) & 0x0000ff00u) <<  8) | (((x) & 0x000000ffu) << 24))
++#endif
+ 
+ struct usb_handle
+ {
+diff --git a/core/adbd/usb_linux_client.c b/core/adbd/usb_linux_client.c
+index 33875a8..0e4d200 100644
+--- a/core/adbd/usb_linux_client.c
++++ b/core/adbd/usb_linux_client.c
+@@ -34,8 +34,15 @@
+ #define MAX_PACKET_SIZE_FS	64
+ #define MAX_PACKET_SIZE_HS	512
+ 
+-#define cpu_to_le16(x)  htole16(x)
+-#define cpu_to_le32(x)  htole32(x)
++#if __BYTE_ORDER == __LITTLE_ENDIAN
++# define cpu_to_le16(x) (x)
++# define cpu_to_le32(x) (x)
++#else
++# define cpu_to_le16(x) ((((x) >> 8) & 0xffu) | (((x) & 0xffu) << 8))
++# define cpu_to_le32(x) \
++	((((x) & 0xff000000u) >> 24) | (((x) & 0x00ff0000u) >>  8) | \
++	 (((x) & 0x0000ff00u) <<  8) | (((x) & 0x000000ffu) << 24))
++#endif
+ 
+ struct usb_handle
+ {
+-- 
+2.47.0
+

--- a/src/adbd-patches/0007-Include-cdefs.h-wherever-it-is-needed.patch
+++ b/src/adbd-patches/0007-Include-cdefs.h-wherever-it-is-needed.patch
@@ -1,0 +1,47 @@
+From d3f0157bf2ac1afc9a810ccbe188110df724129d Mon Sep 17 00:00:00 2001
+From: "Yann E. MORIN" <yann.morin.1998@free.fr>
+Date: Sun, 1 Dec 2024 15:46:15 +0100
+Subject: [PATCH] Include cdefs.h wherever it is needed
+
+cdefs.h is included from within a lot of glibc headers, so it almost
+invariably and automagically gets pulled in with glibc.
+
+However, this might not be the case with other C libraries. musl does
+not provide cdefs.h so it does not include it from its own headers
+(cdefs.h must be provided separately).
+
+So we must include it when we are going to use macros it provides.
+
+Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>
+---
+ core/adbd/services.c            | 1 +
+ core/libcutils/android_reboot.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/core/adbd/services.c b/core/adbd/services.c
+index 5adcefe..6de1951 100644
+--- a/core/adbd/services.c
++++ b/core/adbd/services.c
+@@ -20,6 +20,7 @@
+ #include <string.h>
+ #include <errno.h>
+ #include <pwd.h>
++#include <sys/cdefs.h>
+ 
+ #include "sysdeps.h"
+ 
+diff --git a/core/libcutils/android_reboot.c b/core/libcutils/android_reboot.c
+index 79c05f8..9386006 100644
+--- a/core/libcutils/android_reboot.c
++++ b/core/libcutils/android_reboot.c
+@@ -23,6 +23,7 @@
+ #include <string.h>
+ #include <linux/reboot.h>
+ #include <sys/syscall.h>
++#include <sys/cdefs.h>
+ 
+ #include <cutils/android_reboot.h>
+ 
+-- 
+2.47.0
+

--- a/src/adbd-patches/0008-usb_linux.c-fix-minor-major-build-failure-due-to-gli.patch
+++ b/src/adbd-patches/0008-usb_linux.c-fix-minor-major-build-failure-due-to-gli.patch
@@ -1,0 +1,59 @@
+From 99c20bd08065d9c78d81ba7aa48a2a113ab28c26 Mon Sep 17 00:00:00 2001
+From: Giulio Benetti <giulio.benetti@micronovasrl.com>
+Date: Sun, 1 Dec 2024 15:46:50 +0100
+Subject: [PATCH] usb_linux.c: fix minor()/major() build failure due to glibc
+ 2.28
+
+glibc 2.28 no longer includes <sys/sysmacros.h> from <sys/types.h>,
+and therefore <sys/sysmacros.h> must be included explicitly when
+major()/minor() are used.
+
+This commit adds a patch to directly include <sys/sysmacros.h> into
+all usb_linux.c files where minor() and major() macros are used.
+
+Signed-off-by: Giulio Benetti <giulio.benetti@micronovasrl.com>
+---
+ core/adb/usb_linux.c      | 1 +
+ core/adbd/usb_linux.c     | 1 +
+ core/fastboot/usb_linux.c | 1 +
+ 3 files changed, 3 insertions(+)
+
+diff --git a/core/adb/usb_linux.c b/core/adb/usb_linux.c
+index 7bf2057..f748267 100644
+--- a/core/adb/usb_linux.c
++++ b/core/adb/usb_linux.c
+@@ -20,6 +20,7 @@
+ #include <string.h>
+ 
+ #include <sys/ioctl.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <dirent.h>
+diff --git a/core/adbd/usb_linux.c b/core/adbd/usb_linux.c
+index 7bf2057..f748267 100644
+--- a/core/adbd/usb_linux.c
++++ b/core/adbd/usb_linux.c
+@@ -20,6 +20,7 @@
+ #include <string.h>
+ 
+ #include <sys/ioctl.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <dirent.h>
+diff --git a/core/fastboot/usb_linux.c b/core/fastboot/usb_linux.c
+index b7a9ca3..2dac62b 100644
+--- a/core/fastboot/usb_linux.c
++++ b/core/fastboot/usb_linux.c
+@@ -33,6 +33,7 @@
+ 
+ #include <sys/ioctl.h>
+ #include <sys/stat.h>
++#include <sys/sysmacros.h>
+ #include <sys/types.h>
+ #include <dirent.h>
+ #include <fcntl.h>
+-- 
+2.47.0
+

--- a/src/adbd-patches/0009-Fix-makefiles-for-out-of-tree-ext4_utils-build.patch
+++ b/src/adbd-patches/0009-Fix-makefiles-for-out-of-tree-ext4_utils-build.patch
@@ -1,0 +1,48 @@
+From 3c4319da20fab4e48ec02e28f5b013b4a33b5fe4 Mon Sep 17 00:00:00 2001
+From: Alex Kaplan <kaplan2539@gmail.com>
+Date: Sat, 10 Nov 2018 19:50:51 -0800
+Subject: [PATCH] Fix makefiles for out-of-tree ext4_utils build
+
+Signed-off-by: Alex Kaplan <kaplan2539@gmail.com>
+---
+ debian/makefiles/ext4_utils.mk | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/debian/makefiles/ext4_utils.mk b/debian/makefiles/ext4_utils.mk
+index cb64916..c5904bf 100644
+--- a/debian/makefiles/ext4_utils.mk
++++ b/debian/makefiles/ext4_utils.mk
+@@ -1,6 +1,7 @@
+ # Makefile for ext4_utils; based on https://heiher.info/2227.html
+ # Author: Dmitrijs Ledkovs <xnox@ubuntu.com>
+ 
++VPATH+=$(SRCDIR)/extras/ext4_utils
+ SRCS+=make_ext4fs.c
+ SRCS+=ext4fixup.c
+ SRCS+=ext4_utils.c
+@@ -13,7 +14,7 @@ SRCS+=sha1.c
+ SRCS+=wipe.c
+ SRCS+=crc16.c
+ 
+-VPATH+=../../core/libsparse
++VPATH+=$(SRCDIR)/core/libsparse
+ SRCS+= backed_block.c
+ SRCS+= sparse_crc32.c
+ SRCS+= sparse.c
+@@ -31,10 +32,9 @@ SRCS+=img2simg.c
+ SRCS+=simg2img.c
+ SRCS+=simg2simg.c
+ 
+-CPPFLAGS+= -I.
+-CPPFLAGS+= -I/usr/include
+-CPPFLAGS+= -I../../core/include
+-CPPFLAGS+= -I../../core/libsparse/include/
++CPPFLAGS+= -I$(SRCDIR)
++CPPFLAGS+= -I$(SRCDIR)/core/include
++CPPFLAGS+= -I$(SRCDIR)/core/libsparse/include/
+ 
+ LIBS+= -lz -lselinux
+ 
+-- 
+2.47.0
+

--- a/src/adbd-patches/0010-adb-added-patch-for-openssl-1.1.0-compatibility.patch
+++ b/src/adbd-patches/0010-adb-added-patch-for-openssl-1.1.0-compatibility.patch
@@ -1,0 +1,47 @@
+From 79bf5cdee607241434e0d1c5b72e724eb1d20102 Mon Sep 17 00:00:00 2001
+From: Eneas U de Queiroz <cote2004-github@yahoo.com>
+Date: Tue, 5 Feb 2019 01:12:19 +0200
+Subject: [PATCH] adb: added patch for openssl 1.1.0 compatibility
+
+Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>
+
+[Vadim: took only adb related part from
+https://github.com/lede-project/source/commit/f63f20fb93c7e67775cb01d97fc88b5b29452b81]
+Signed-off-by: Vadim Kochan <vadim4j@gmail.com>
+---
+ core/adb/adb_auth_host.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/core/adb/adb_auth_host.c b/core/adb/adb_auth_host.c
+index 9039d42..debd2ef 100644
+--- a/core/adb/adb_auth_host.c
++++ b/core/adb/adb_auth_host.c
+@@ -79,7 +79,13 @@ static int RSA_to_RSAPublicKey(RSA *rsa, RSAPublicKey *pkey)
+     }
+ 
+     BN_set_bit(r32, 32);
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    const BIGNUM *rsa_n, *rsa_e;
++    RSA_get0_key(rsa, &rsa_n, &rsa_e, NULL);
++    BN_copy(n, rsa_n);
++#else
+     BN_copy(n, rsa->n);
++#endif
+     BN_set_bit(r, RSANUMWORDS * 32);
+     BN_mod_sqr(rr, r, n, ctx);
+     BN_div(NULL, rem, n, r32, ctx);
+@@ -93,7 +99,11 @@ static int RSA_to_RSAPublicKey(RSA *rsa, RSAPublicKey *pkey)
+         BN_div(n, rem, n, r32, ctx);
+         pkey->n[i] = BN_get_word(rem);
+     }
++#if OPENSSL_VERSION_NUMBER >= 0x10100000L
++    pkey->exponent = BN_get_word(rsa_e);
++#else
+     pkey->exponent = BN_get_word(rsa->e);
++#endif
+ 
+ out:
+     BN_free(n0inv);
+-- 
+2.47.0
+

--- a/src/adbd-patches/0011-core-fastboot-fastboot.c-reorder-functions-to-avoid-.patch
+++ b/src/adbd-patches/0011-core-fastboot-fastboot.c-reorder-functions-to-avoid-.patch
@@ -1,0 +1,54 @@
+From 6919b6619a9c744d2220f7af6e211c50662ba94b Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Sun, 14 Jul 2024 11:41:10 +0200
+Subject: [PATCH] core/fastboot/fastboot.c: reorder functions to avoid implicit
+ definition
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The match_fastboot() function uses match_fastboot_with_serial() but is
+implemented before it, causing an implicit definition. Re-order the
+functions to avoid this.
+
+Fixes:
+
+core/fastboot/fastboot.c:191:12: error: implicit declaration of function ‘match_fastboot_with_serial’ [-Wimplicit-function-declaration]
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ core/fastboot/fastboot.c | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/core/fastboot/fastboot.c b/core/fastboot/fastboot.c
+index 3de6d7d..9b2c86f 100644
+--- a/core/fastboot/fastboot.c
++++ b/core/fastboot/fastboot.c
+@@ -186,11 +186,6 @@ oops:
+ }
+ #endif
+ 
+-int match_fastboot(usb_ifc_info *info)
+-{
+-    return match_fastboot_with_serial(info, serial);
+-}
+-
+ int match_fastboot_with_serial(usb_ifc_info *info, const char *local_serial)
+ {
+     if(!(vendor_id && (info->dev_vendor == vendor_id)) &&
+@@ -217,6 +212,11 @@ int match_fastboot_with_serial(usb_ifc_info *info, const char *local_serial)
+     return 0;
+ }
+ 
++int match_fastboot(usb_ifc_info *info)
++{
++    return match_fastboot_with_serial(info, serial);
++}
++
+ int list_devices_callback(usb_ifc_info *info)
+ {
+     if (match_fastboot_with_serial(info, NULL) == 0) {
+-- 
+2.47.0
+

--- a/src/adbd-patches/0012-core-libsparse-sparse_read.c-add-missing-output_file.patch
+++ b/src/adbd-patches/0012-core-libsparse-sparse_read.c-add-missing-output_file.patch
@@ -1,0 +1,37 @@
+From 72b9e79c81a237f1839afb4fdee680eafdd180d9 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Sun, 14 Jul 2024 11:41:56 +0200
+Subject: [PATCH] core/libsparse/sparse_read.c: add missing output_file.h
+ include
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+sparse_read.c uses read_all() without including the header file
+containing its prototype, causing:
+
+core/libsparse/sparse_read.c:122:31: error: implicit declaration of function ‘read_all’ [-Wimplicit-function-declaration]
+
+Fix this by including output_file.h.
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ core/libsparse/sparse_read.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/core/libsparse/sparse_read.c b/core/libsparse/sparse_read.c
+index 704bcfa..0a8f838 100644
+--- a/core/libsparse/sparse_read.c
++++ b/core/libsparse/sparse_read.c
+@@ -32,6 +32,7 @@
+ #include "sparse_crc32.h"
+ #include "sparse_file.h"
+ #include "sparse_format.h"
++#include "output_file.h"
+ 
+ #if defined(__APPLE__) && defined(__MACH__)
+ #define lseek64 lseek
+-- 
+2.47.0
+

--- a/src/adbd-patches/0013-extras-ext4_utils-make_ext4fs_main.c-disable-Android.patch
+++ b/src/adbd-patches/0013-extras-ext4_utils-make_ext4fs_main.c-disable-Android.patch
@@ -1,0 +1,54 @@
+From 01e86db8460d873aec15d658bfc717b026c0545f Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Sun, 14 Jul 2024 11:46:51 +0200
+Subject: [PATCH] extras/ext4_utils/make_ext4fs_main.c: disable
+ Android-specific code
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since we are not building with the Android code, we do not have the
+implementation of the selinux_android_file_context_handle(). However,
+its only call site is when 'mountpoint' is set, and 'mountpoint'
+cannot be non-NULL in non-Android cases due to how the -a option is
+parsed:
+
+		case 'a':
+ #ifdef ANDROID
+			fs_config_func = fs_config;
+			mountpoint = optarg;
+ #else
+			fprintf(stderr, "can't set android permissions - built without android support\n");
+			usage(argv[0]);
+			exit(EXIT_FAILURE);
+ #endif
+
+So also compile out the code calling
+selinux_android_file_context_handle() when ANDROID is not set.
+
+Fixes:
+
+make_ext4fs_main.c:155:25: error: implicit declaration of function ‘selinux_android_file_context_handle’ [-Wimplicit-function-declaration]
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ extras/ext4_utils/make_ext4fs_main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/extras/ext4_utils/make_ext4fs_main.c b/extras/ext4_utils/make_ext4fs_main.c
+index 17d3735..cb58011 100644
+--- a/extras/ext4_utils/make_ext4fs_main.c
++++ b/extras/ext4_utils/make_ext4fs_main.c
+@@ -149,7 +149,7 @@ int main(int argc, char **argv)
+ 		}
+ 	}
+ 
+-#if !defined(HOST)
++#if !defined(HOST) && defined(ANDROID)
+ 	// Use only if -S option not requested
+ 	if (!sehnd && mountpoint) {
+ 		sehnd = selinux_android_file_context_handle();
+-- 
+2.47.0
+

--- a/src/adbd-patches/0014-core-adbd-adb.c-open-code-capset.patch
+++ b/src/adbd-patches/0014-core-adbd-adb.c-open-code-capset.patch
@@ -1,0 +1,52 @@
+From 850fd3f4a0384ebe492a466a9b1149060619aacb Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Sun, 14 Jul 2024 12:57:22 +0200
+Subject: [PATCH] core/adbd/adb.c: open code capset()
+
+capset() is apparently implemented by C libraries (at least glibc and
+musl), but not exposed through a header as an official public API.
+
+In addition capset(2) says:
+
+  Note: glibc provides no wrappers for these system calls,
+  necessitating the use of syscall(2)
+
+The lack of a header with a prototype for capset() was not causing any
+problem so far, but GCC 14.x has become stricter on implicit
+declarations, causing the build to fail with:
+
+core/adbd/adb.c:1296:9: error: implicit declaration of function 'capset' [-Wimplicit-function-declaration]
+
+So fix that by open-coding it using syscall() as suggested by the man
+page.
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ core/adbd/adb.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/core/adbd/adb.c b/core/adbd/adb.c
+index 7fe6445..98b1de1 100644
+--- a/core/adbd/adb.c
++++ b/core/adbd/adb.c
+@@ -41,6 +41,7 @@
+ #if !ADB_HOST
+ #include "android_filesystem_config.h"
+ #include <linux/capability.h>
++#include <sys/syscall.h>
+ #include <linux/prctl.h>
+ #include <sys/mount.h>
+ #else
+@@ -1293,7 +1294,7 @@ int adb_main(int is_daemon, int server_port)
+         header.pid = 0;
+         cap[CAP_TO_INDEX(CAP_SYS_BOOT)].effective |= CAP_TO_MASK(CAP_SYS_BOOT);
+         cap[CAP_TO_INDEX(CAP_SYS_BOOT)].permitted |= CAP_TO_MASK(CAP_SYS_BOOT);
+-        capset(&header, cap);
++        syscall(SYS_capset, &header, cap);
+ 
+         D("Local port disabled\n");
+     } else {
+-- 
+2.47.0
+

--- a/src/adbd-patches/0015-core-adbd-adb.c-include-correct-header-for-prctl.patch
+++ b/src/adbd-patches/0015-core-adbd-adb.c-include-correct-header-for-prctl.patch
@@ -1,0 +1,34 @@
+From 8f351150de38641c8ce2e9b7f9a5cba29ccd8f7e Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Sun, 14 Jul 2024 13:00:02 +0200
+Subject: [PATCH] core/adbd/adb.c: include correct header for prctl()
+
+As documented by prctl(2), the correct header to include for prctl()
+is <sys/prctl.h>, not <linux/prctl.h>.
+
+Fixes:
+
+core/adbd/adb.c:1256:13: error: implicit declaration of function 'prctl' [-Wimplicit-function-declaration]
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ core/adbd/adb.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/core/adbd/adb.c b/core/adbd/adb.c
+index 98b1de1..10f420b 100644
+--- a/core/adbd/adb.c
++++ b/core/adbd/adb.c
+@@ -42,7 +42,7 @@
+ #include "android_filesystem_config.h"
+ #include <linux/capability.h>
+ #include <sys/syscall.h>
+-#include <linux/prctl.h>
++#include <sys/prctl.h>
+ #include <sys/mount.h>
+ #else
+ #include "usb_vendors.h"
+-- 
+2.47.0
+

--- a/src/adbd-patches/0016-extras-ext4_utils-make_ext4fs.c-define-__SANE_USERSP.patch
+++ b/src/adbd-patches/0016-extras-ext4_utils-make_ext4fs.c-define-__SANE_USERSP.patch
@@ -1,0 +1,68 @@
+From 5db9529436f13b8c073a0310da3a1107f84645da Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Wed, 4 Dec 2024 20:51:22 +0100
+Subject: [PATCH] extras/ext4_utils/make_ext4fs.c: define
+ __SANE_USERSPACE_TYPES__
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Debian patch ppc64el-ftbfs.patch is already defining
+__SANE_USERSPACE_TYPES__ in a few files to solve a conflict between
+kernel header definitions and local definition of some types, on
+powerpc64 and mips64.
+
+However, the Debian patch lacks an update to ext4_utils.c, and has the
+definition too late in make_ext4fs.c. This commit therefore fixes
+those two remaining issues, fixing:
+
+error: conflicting types for ‘u64’; have ‘long unsigned int’
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ extras/ext4_utils/ext4_utils.c  | 5 ++++-
+ extras/ext4_utils/make_ext4fs.c | 4 ++++
+ 2 files changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/extras/ext4_utils/ext4_utils.c b/extras/ext4_utils/ext4_utils.c
+index e95f5cc..9f6836f 100644
+--- a/extras/ext4_utils/ext4_utils.c
++++ b/extras/ext4_utils/ext4_utils.c
+@@ -14,6 +14,10 @@
+  * limitations under the License.
+  */
+ 
++#if defined(__linux__)
++#define __SANE_USERSPACE_TYPES__
++#endif
++
+ #include "ext4_utils.h"
+ #include "uuid.h"
+ #include "allocate.h"
+@@ -36,7 +40,6 @@
+ #endif
+ 
+ #if defined(__linux__)
+-#define __SANE_USERSPACE_TYPES__
+ #include <linux/fs.h>
+ #elif defined(__APPLE__) && defined(__MACH__)
+ #include <sys/disk.h>
+diff --git a/extras/ext4_utils/make_ext4fs.c b/extras/ext4_utils/make_ext4fs.c
+index 3124aed..332a213 100644
+--- a/extras/ext4_utils/make_ext4fs.c
++++ b/extras/ext4_utils/make_ext4fs.c
+@@ -14,6 +14,10 @@
+  * limitations under the License.
+  */
+ 
++#if defined(__linux__)
++#define __SANE_USERSPACE_TYPES__
++#endif
++
+ #include "make_ext4fs.h"
+ #include "ext4_utils.h"
+ #include "allocate.h"
+-- 
+2.47.0
+

--- a/src/adbd-patches/0017-extras-ext4_utils-contents.c-allocate_inode-doesn-t-.patch
+++ b/src/adbd-patches/0017-extras-ext4_utils-contents.c-allocate_inode-doesn-t-.patch
@@ -1,0 +1,57 @@
+From b822c8e2f380ba6158601e621a12927a4264ff67 Mon Sep 17 00:00:00 2001
+From: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+Date: Fri, 16 May 2025 15:32:00 +0200
+Subject: [PATCH] extras/ext4_utils/contents.c: allocate_inode() doesn't take
+ any argument
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+
+/home/thomas/projets/buildroot/output/build/host-android-tools-4.2.2+git20130218/extras/ext4_utils/contents.c: In function ‘make_directory’:
+/home/thomas/projets/buildroot/output/build/host-android-tools-4.2.2+git20130218/extras/ext4_utils/contents.c:102:29: error: too many arguments to function ‘allocate_inode’; expected 0, have 1
+  102 |                 inode_num = allocate_inode(info);
+
+and similar build failures that occur with GCC 15.x.
+
+Upstream: N/A, we're too far from upstream
+Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>
+---
+ extras/ext4_utils/contents.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/extras/ext4_utils/contents.c b/extras/ext4_utils/contents.c
+index 6300680..b0336a4 100644
+--- a/extras/ext4_utils/contents.c
++++ b/extras/ext4_utils/contents.c
+@@ -99,7 +99,7 @@ u32 make_directory(u32 dir_inode_num, u32 entries, struct dentry *dentries,
+ 	len = blocks * info.block_size;
+ 
+ 	if (dir_inode_num) {
+-		inode_num = allocate_inode(info);
++		inode_num = allocate_inode();
+ 	} else {
+ 		dir_inode_num = EXT4_ROOT_INO;
+ 		inode_num = EXT4_ROOT_INO;
+@@ -167,7 +167,7 @@ u32 make_file(const char *filename, u64 len)
+ 	struct ext4_inode *inode;
+ 	u32 inode_num;
+ 
+-	inode_num = allocate_inode(info);
++	inode_num = allocate_inode();
+ 	if (inode_num == EXT4_ALLOCATE_FAILED) {
+ 		error("failed to allocate inode\n");
+ 		return EXT4_ALLOCATE_FAILED;
+@@ -196,7 +196,7 @@ u32 make_link(const char *filename, const char *link)
+ 	u32 inode_num;
+ 	u32 len = strlen(link);
+ 
+-	inode_num = allocate_inode(info);
++	inode_num = allocate_inode();
+ 	if (inode_num == EXT4_ALLOCATE_FAILED) {
+ 		error("failed to allocate inode\n");
+ 		return EXT4_ALLOCATE_FAILED;
+-- 
+2.49.0
+

--- a/src/adbd-patches/0100-adbd-stay-root.patch
+++ b/src/adbd-patches/0100-adbd-stay-root.patch
@@ -1,0 +1,35 @@
+From: BaseOS <baseos@localhost>
+Date: Thu, 24 Jul 2026 00:00:00 +0000
+Subject: [PATCH] core/adbd/adb.c: always keep root (never drop privileges)
+
+BaseOS dev images are root-everything: dropbear runs root/root and there
+is no unprivileged shell account. Android's should_drop_privileges() drops
+to uid 2000 (AID_SHELL), which does not exist in our /etc/passwd, so the
+drop path (getpwuid(AID_SHELL) -> getspnam -> setgid/setuid) either crashes
+adbd or yields a broken, shell-less session.
+
+The Buildroot/Debian series already forces `return 0` inside the
+ALLOW_ADBD_ROOT branch, but that depends on adbd.mk keeping
+-DALLOW_ADBD_ROOT=1. This patch makes staying root explicit and
+build-flag independent by returning 0 at the top of the function.
+
+Upstream: N/A, BaseOS-local.
+---
+diff --git a/core/adbd/adb.c b/core/adbd/adb.c
+index 10f420b..67504e7 100644
+--- a/core/adbd/adb.c
++++ b/core/adbd/adb.c
+@@ -1166,6 +1166,11 @@ void build_local_name(char* target_str, size_t target_size, int server_port)
+ 
+ #if !ADB_HOST
+ static int should_drop_privileges() {
++    /* BaseOS: dev images are root-everything (dropbear runs root/root) and
++     * Android uid 2000 (AID_SHELL) has no passwd entry here, so any
++     * privilege drop would abort adbd or hand out a broken shell.
++     * Unconditionally keep root. */
++    return 0;
+ #ifndef ALLOW_ADBD_ROOT
+     return 1;
+ #else /* ALLOW_ADBD_ROOT */
+-- 
+2.47.0

--- a/src/adbd-patches/0101-adbd-usb-only-no-tcp.patch
+++ b/src/adbd-patches/0101-adbd-usb-only-no-tcp.patch
@@ -1,0 +1,39 @@
+From: BaseOS <baseos@localhost>
+Date: Thu, 24 Jul 2026 00:00:01 +0000
+Subject: [PATCH] core/adbd/adb.c: USB-only, drop network TCP fallback
+
+The Debian add_adbd.patch rewrote adb_main() so that when no USB gadget
+(/dev/android_adb or /dev/usb-ffs/adb/ep0) is present, adbd falls back to
+local_init(DEFAULT_ADB_LOCAL_TRANSPORT_PORT), which calls
+socket_inaddr_any_server() and listens on 0.0.0.0:5555. Combined with the
+BaseOS stay-root patch that is an unauthenticated root shell on the network.
+
+BaseOS uses adb over USB (FunctionFS) only, so remove the TCP fallback.
+If FunctionFS is not up, adbd simply serves no transport. The loopback-only
+smartsocket (127.0.0.1:5037) opened elsewhere is unaffected and is not
+network-reachable.
+
+Upstream: N/A, BaseOS-local.
+---
+diff --git a/core/adbd/adb.c b/core/adbd/adb.c
+index 67504e7..1dbc351 100644
+--- a/core/adbd/adb.c
++++ b/core/adbd/adb.c
+@@ -1329,11 +1329,10 @@ int adb_main(int is_daemon, int server_port)
+         // listen on TCP port specified by service.adb.tcp.port property
+     //    local_init(port);
+     //} else 
+-    if (!usb) {
+-        printf("Using USB\n");
+-        // listen on default port
+-        local_init(DEFAULT_ADB_LOCAL_TRANSPORT_PORT);
+-    }
++    /* BaseOS: USB-only image. Do not fall back to a network-reachable adb
++     * transport -- local_init() here would socket_inaddr_any_server() on
++     * 0.0.0.0:5555 and expose an unauthenticated root shell. If FunctionFS
++     * is not up, adbd simply serves no transport. */
+ 
+     D("adb_main(): pre init_jdwp()\n");
+     init_jdwp();
+-- 
+2.47.0

--- a/src/adbd-patches/README
+++ b/src/adbd-patches/README
@@ -1,0 +1,21 @@
+android-tools (adbd) patch series
+==================================
+
+The 00xx patches are Buildroot's android-tools patch series, vendored verbatim
+from package/android-tools/ at Buildroot commit
+8c96a8981f40689c352910372404216ab0d9482e
+(https://github.com/buildroot/buildroot/tree/8c96a8981f40689c352910372404216ab0d9482e/package/android-tools).
+They are checked in here (rather than fetched at build time) so that
+build-tools.sh produces a byte-reproducible adbd from a clean, offline
+checkout. They are applied on top of android-tools 4.2.2+git20130218 after the
+upstream Debian quilt series (debian/patches/*), matching android-tools.mk.
+
+The 01xx patches are BaseOS-local, applied last:
+
+  0100-adbd-stay-root.patch     adbd never drops privileges (root shell). Our
+                                dev images are root-everything and have no
+                                AID_SHELL (uid 2000) account, so Android's
+                                privilege drop would break the shell.
+  0101-adbd-usb-only-no-tcp.patch  Remove the network TCP fallback so adbd only
+                                serves adb over USB (FunctionFS); it never
+                                opens 0.0.0.0:5555.

--- a/tests/test-usb-gadget-adb.sh
+++ b/tests/test-usb-gadget-adb.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$HERE/overlay/usr/sbin/usb-gadget-adb"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT HUP INT TERM
+
+# Build a fake /sys tree: one UDC and an (empty) configfs usb_gadget dir. On
+# macOS these are all just ordinary files/dirs, so the script's mkdir/echo
+# against them work with no root and no Linux. Note the script deliberately does
+# NOT touch usbc0/otg_role (writing it wedges the real vendor kernel), so the
+# fake tree needs no role-manager node.
+build_tree() {
+	root="$1"
+	mkdir -p "$root/class/udc/5100000.udc-controller" \
+	         "$root/kernel/config/usb_gadget"
+}
+
+run_gadget() {
+	sys="$1"
+	BASEOS_SYS_ROOT="$sys" \
+	BASEOS_FFS_DIR="$TMP/ffs" \
+		sh "$SCRIPT"
+}
+
+# --- Happy path -----------------------------------------------------------
+build_tree "$TMP/sys"
+run_gadget "$TMP/sys"
+
+G="$TMP/sys/kernel/config/usb_gadget/g1"
+
+# Gadget attributes.
+[ "$(cat "$G/idVendor")" = "0x18d1" ]
+[ "$(cat "$G/idProduct")" = "0x4e42" ]
+[ -s "$G/strings/0x409/serialnumber" ]
+[ -s "$G/strings/0x409/manufacturer" ]
+[ -s "$G/strings/0x409/product" ]
+[ -d "$G/configs/c.1" ]
+[ -d "$G/functions/ffs.adb" ]
+[ -L "$G/configs/c.1/ffs.adb" ]
+
+# Bound to the fake UDC.
+[ "$(cat "$G/UDC")" = "5100000.udc-controller" ]
+
+# --- Idempotent second run is a no-op -------------------------------------
+# A bound gadget must be left untouched. Stamp a marker, re-run, confirm the
+# gadget tree is byte-for-byte identical and the marker survives.
+echo marker > "$G/strings/0x409/product"
+before="$(find "$G" | sort; cat "$G/strings/0x409/product")"
+run_gadget "$TMP/sys"
+after="$(find "$G" | sort; cat "$G/strings/0x409/product")"
+[ "$before" = "$after" ] || { echo "second run mutated the gadget" >&2; exit 1; }
+
+# --- No UDC present exits 0 quickly ---------------------------------------
+# An empty /sys (no udc, no configfs) must be a silent no-op.
+mkdir -p "$TMP/sys2/class/udc"
+run_gadget "$TMP/sys2"
+[ ! -d "$TMP/sys2/kernel/config/usb_gadget/g1" ] \
+	|| { echo "gadget composed with no UDC present" >&2; exit 1; }
+
+echo "usb-gadget-adb tests passed"

--- a/validate-on-device.sh
+++ b/validate-on-device.sh
@@ -25,8 +25,8 @@ chk "no systemd running"                        "! pidof systemd"
 chk "busybox is init (PID 1)"                   "grep -q busybox /proc/1/comm || readlink /proc/1/exe | grep -q busybox"
 
 echo "=== boot speed ==="
-for m in rcS-start rcS-done frontend-exec; do
-	[ -f /run/boot-$m ] && echo "  boot-$m: $(cat /run/boot-$m)s"
+for m in rcS-start rcS-done frontend-exec dev-done adb-gadget-done; do
+	if [ -f /run/boot-$m ]; then echo "  boot-$m: $(cat /run/boot-$m)s"; else echo "  boot-$m: (absent)"; fi
 done
 chk "frontend exec marker exists" "test -f /run/boot-frontend-exec"
 
@@ -51,6 +51,16 @@ echo "=== NextUI ==="
 chk "SD card mounted (/mnt/sdcard)"    "mountpoint -q /mnt/sdcard"
 chk "nextui.elf running"               "pidof nextui.elf"
 chk "keymon running"                   "pidof keymon.elf"
+
+echo "=== dev services ==="
+chk "adbd running"                      "pidof adbd"
+# The adb gadget is bound to the always-present UDC; device (peripheral) mode is
+# auto-selected by the sunxi manager on cable attach. We deliberately do NOT
+# force usbc0/otg_role — writing it wedges the writer in D-state on this vendor
+# kernel, and its siblings usb_device/usb_host/usb_null are read-triggers that
+# switch the role on cat. So the check is "gadget bound", not "role == device".
+chk "adb gadget bound (g1/UDC)"         "test -s /sys/kernel/config/usb_gadget/g1/UDC"
+chk "functionfs mounted"                "grep -q functionfs /proc/mounts"
 
 echo "=== resources ==="
 echo "  processes: $(ps | wc -l)"


### PR DESCRIPTION
## What

A developer convenience for dev-flavour images, alongside the existing dropbear SSH: **adb over USB** — a static `adbd` served over a configfs **FunctionFS** gadget composed by the new `overlay/usr/sbin/usb-gadget-adb`, launched backgrounded from `init.d/dev` like dropbear. **USB-only, no TCP.**

## Why / how

`adbd` is built from **android-tools 4.2.2+git20130218 + the Buildroot patch series**, vendored offline in `src/adbd-patches/` (provenance in the README). Two BaseOS-local patches gate a real hole: `0101` removes adbd's `0.0.0.0:5555` TCP fallback (which, combined with staying root, would be an unauthenticated root shell over WiFi); `0100` keeps root since there's no unprivileged shell account here. The tool is built in `build-tools.sh` (pinned + SHA256-verified, static) and installed + closure-whitelisted in `build-rootfs.sh`.

## Reviewer notes — the `otg_role` trap

The obvious design (force USB device mode by writing `usbc0/otg_role`) is a **trap** on the 4.9.170 vendor kernel: that write **wedges the writer in uninterruptible D-state forever** — reproduced both with and without a gadget bound; only a reboot clears it. Its `usb_device`/`usb_host`/`usb_null` siblings are 0400 **read-triggers** that switch the role on a bare `cat`. The gadget script therefore **never touches the role** — it binds to the always-present UDC and lets the sunxi manager auto-select peripheral mode on cable attach (this also leaves charging on the shared USB-C port undisturbed). Documented in `docs/05` §6 and `docs/06`.

**Open issue from review:** the host-vs-device USB detection has a race that causes the handheld to randomly charge the Mac instead of enumerating as a gadget (charging works, adb doesn't, intermittently). Still being tracked down — see PR comments.

## Boot-time impact

Boot time is a headline feature, so nothing was added to the synchronous path: the gadget script is backgrounded off the already-backgrounded `init.d/dev`. New markers `/run/boot-dev-done` and `/run/boot-adb-gadget-done` make the cost observable. Measured on rg40xxv: `frontend-exec` **3.01s → 3.05s** (+0.04s, within boot-to-boot jitter, under the 0.05s bar); the gadget binds at ~3.35s, after the frontend hands off.

## Testing

- `build-tools.sh` produces the aarch64 static binary; `build-rootfs.sh rg40xxv` passes ELF closure.
- New `tests/test-usb-gadget-adb.sh` (fake-sysfs unit test) + existing `test-timedatectl.sh` pass.
- **Verified live on an rg40xxv (deployed + rebooted):** `adbd` running, FunctionFS mounted, gadget `g1` bound to the UDC, `adb devices`/`adb shell` over a physical USB-C cable confirmed, no stuck processes, boot regression within jitter.

`validate-on-device.sh` gains dev-service checks (adbd, gadget bound, functionfs) and prints all boot markers so every run doubles as a boot-time measurement. Docs 01/05/06 updated.

---

SFTP support (previously bundled here) is now its own PR: #8.