### PR TITLE
feat(runtime): add SFTP dev access over dropbear

### DIFF
--- a/build-rootfs.sh
+++ b/build-rootfs.sh
@@ -112,8 +112,8 @@ docker run --rm --platform linux/arm64 \
   done
   ln -sf ../sbin/dropbearmulti "$R/usr/bin/scp"
   # dropbear 2024.85 compiles its default SFTPSERVER_PATH as
-  # /usr/libexec/sftp-server; installing the binary there makes sftp / Finder /
-  # FileZilla work with zero dropbear config changes.
+  # /usr/libexec/sftp-server; installing the binary there makes sftp / Forklift /
+  # scp work with zero dropbear config changes.
   cp /tools/sftp-server "$R/usr/libexec/sftp-server"
   chmod 755 "$R/usr/libexec/sftp-server"
 

--- a/build-rootfs.sh
+++ b/build-rootfs.sh
@@ -17,7 +17,7 @@ TOOLS="$HERE/work/tools"
 
 [ -f "$WORK/source.json" ] || { echo "missing $WORK/source.json (run prepare-stock.sh $TARGET IMAGE)"; exit 1; }
 [ -f "$WORK/stock-harvest.tar" ] || { echo "missing $WORK/stock-harvest.tar (run prepare-stock.sh $TARGET IMAGE)"; exit 1; }
-for tool in busybox dropbearmulti curl fbsplash gptgrow; do
+for tool in busybox dropbearmulti curl fbsplash gptgrow sftp-server; do
   [ -x "$TOOLS/$tool" ] || { echo "missing $TOOLS/$tool (run build-tools.sh)"; exit 1; }
 done
 [ -f "$TOOLS/ca-certificates.crt" ] \
@@ -105,12 +105,17 @@ docker run --rm --platform linux/arm64 \
   ln -sf /run/localtime "$R/etc/localtime"
   ln -sf /proc/self/mounts "$R/etc/mtab"
 
-  ## 6. Dropbear (dev flavour)
+  ## 6. Dropbear + SFTP (dev flavour)
   cp /tools/dropbearmulti "$R/usr/sbin/dropbearmulti"
   for n in dropbear dropbearkey dbclient scp; do
     ln -sf dropbearmulti "$R/usr/sbin/$n"
   done
   ln -sf ../sbin/dropbearmulti "$R/usr/bin/scp"
+  # dropbear 2024.85 compiles its default SFTPSERVER_PATH as
+  # /usr/libexec/sftp-server; installing the binary there makes sftp / Finder /
+  # FileZilla work with zero dropbear config changes.
+  cp /tools/sftp-server "$R/usr/libexec/sftp-server"
+  chmod 755 "$R/usr/libexec/sftp-server"
 
   ## 6a. Static curl + CA roots for the NextUI RetroAchievements HTTP client.
   cp /tools/curl "$R/usr/bin/curl"
@@ -151,7 +156,7 @@ docker run --rm --platform linux/arm64 \
   find "$R/usr/bin" "$R/usr/sbin" "$R/usr/libexec" -type f | while read -r f; do
     head -c4 "$f" | grep -q "^.ELF" || continue
     case "$f" in
-      */busybox|*/dropbearmulti|*/curl|*/fbsplash|*/gptgrow|*/ldconfig|*/ldconfig.real|*/rtk_hciattach) continue ;;
+      */busybox|*/dropbearmulti|*/curl|*/fbsplash|*/gptgrow|*/ldconfig|*/ldconfig.real|*/rtk_hciattach|*/sftp-server) continue ;;
     esac
     if ! chroot "$R" /usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1 --list \
         "${f#"$R"}" 2>/dev/null | grep -q "=>"; then

--- a/build-tools.sh
+++ b/build-tools.sh
@@ -5,6 +5,9 @@
 #   work/tools/dropbearmulti  (static dropbear + dropbearkey + dbclient + scp)
 #   work/tools/curl           (static HTTPS client used by RetroAchievements)
 #   work/tools/ca-certificates.crt (TLS trust store)
+#   work/tools/fbsplash       (framebuffer boot splash)
+#   work/tools/gptgrow        (grow last GPT partition on first boot)
+#   work/tools/sftp-server    (OpenSSH sftp subsystem child for dropbear)
 # Runs entirely in a linux/arm64 container (native on Apple Silicon).
 set -eu
 
@@ -74,11 +77,34 @@ docker run --rm --platform linux/arm64 \
   strip /out/gptgrow
 '
 
+# sftp-server: dropbear 2024.85 ships the sftp subsystem execing
+# SFTPSERVER_PATH=/usr/libexec/sftp-server, so the transport (owned by dropbear)
+# hands each sftp session to this OpenSSH helper. It needs no crypto of its own,
+# so build it without OpenSSL and without zlib for a small static binary.
+docker run --rm --platform linux/arm64 -v "$TOOLS":/out alpine:3.20 sh -euc '
+  apk add -q build-base linux-headers ca-certificates zlib-dev zlib-static
+  OPENSSH_VERSION=10.4p1
+  OPENSSH_SHA256=ef6026dd2aea8d56059638d5d3262902c892ceba9f88395835e0d06d3fb63238
+  cd /tmp
+  wget -q "https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-$OPENSSH_VERSION.tar.gz"
+  echo "$OPENSSH_SHA256  openssh-$OPENSSH_VERSION.tar.gz" | sha256sum -c -
+  tar xf "openssh-$OPENSSH_VERSION.tar.gz"
+  cd "openssh-$OPENSSH_VERSION"
+  ./configure --without-openssl --without-zlib --without-pam LDFLAGS=-static >/dev/null
+  make sftp-server >/dev/null
+  strip sftp-server
+  cp sftp-server /out/sftp-server
+  chmod 755 /out/sftp-server
+'
+
 file "$TOOLS/busybox" "$TOOLS/dropbearmulti" "$TOOLS/curl" \
-  "$TOOLS/fbsplash" "$TOOLS/gptgrow" 2>/dev/null || true
+  "$TOOLS/fbsplash" "$TOOLS/gptgrow" "$TOOLS/sftp-server" 2>/dev/null || true
 [ -x "$TOOLS/curl" ] || { echo "curl build did not produce an executable" >&2; exit 1; }
 file "$TOOLS/curl" | grep -q "statically linked" \
   || { echo "curl build is not static" >&2; exit 1; }
 [ -s "$TOOLS/ca-certificates.crt" ] \
   || { echo "curl CA bundle is missing or empty" >&2; exit 1; }
+[ -x "$TOOLS/sftp-server" ] || { echo "sftp-server build did not produce an executable" >&2; exit 1; }
+file "$TOOLS/sftp-server" | grep -q "statically linked" \
+  || { echo "sftp-server build is not static" >&2; exit 1; }
 ls -lh "$TOOLS"

--- a/docs/01-rootfs-and-init.md
+++ b/docs/01-rootfs-and-init.md
@@ -101,8 +101,8 @@ ttyS0::respawn:/sbin/getty -L ttyS0 115200 vt100   # serial console (harmless wi
 8. mount the NextUI card: TF2 (`/dev/mmcblk1p1`) if present, else this card's own
    `/dev/mmcblk0p8` → `/mnt/sdcard`, plus the `/mnt/SDCARD` compat symlink; write a
    boot breadcrumb to the card
-9. paint `fbsplash 55`; start dev extras (`/etc/init.d/dev` → dropbear) in the
-   background
+9. paint `fbsplash 55`; start dev extras (`/etc/init.d/dev` → dropbear SSH/sftp-server)
+   in the background
 
 No udev, no mdev: devtmpfs auto-creates nodes, SDL runs with
 `SDL_JOYSTICK_DISABLE_UDEV=1`, BlueZ makes its own uinput nodes, and `dbus-daemon`

--- a/docs/06-status-and-lessons.md
+++ b/docs/06-status-and-lessons.md
@@ -11,7 +11,7 @@
 | Seamless bootlogo → fbsplash illumination | ✅ |
 | Deep sleep (real suspend-to-RAM, ~0 drain / 35 min) | ✅ |
 | WiFi unaided bring-up + stable association | ✅ (validated when the frontend's `wifi_init.sh` did the wait; the Base-OS-owned `wlan0` bring-up is not yet hardware-validated) |
-| Dropbear SSH + sftp over WiFi | ✅ (SSH validated; sftp-server wired but not yet re-validated on hardware) |
+| Dropbear SSH + sftp over WiFi | ✅ (SSH + sftp-server validated on hardware via Forklift and scp) |
 | GLES video / input / audio in NextUI | ✅ (NextUI runs; port already validated these) |
 | Bluetooth audio pairing end-to-end | ⏳ daemons run; not yet paired on base OS |
 | HDMI output | ⏳ not retested on base OS |

--- a/docs/06-status-and-lessons.md
+++ b/docs/06-status-and-lessons.md
@@ -11,7 +11,7 @@
 | Seamless bootlogo → fbsplash illumination | ✅ |
 | Deep sleep (real suspend-to-RAM, ~0 drain / 35 min) | ✅ |
 | WiFi unaided bring-up + stable association | ✅ (validated when the frontend's `wifi_init.sh` did the wait; the Base-OS-owned `wlan0` bring-up is not yet hardware-validated) |
-| Dropbear SSH over WiFi | ✅ |
+| Dropbear SSH + sftp over WiFi | ✅ (SSH validated; sftp-server wired but not yet re-validated on hardware) |
 | GLES video / input / audio in NextUI | ✅ (NextUI runs; port already validated these) |
 | Bluetooth audio pairing end-to-end | ⏳ daemons run; not yet paired on base OS |
 | HDMI output | ⏳ not retested on base OS |
@@ -63,8 +63,8 @@ superblock mount-counts, and `fbsplash` breadcrumbs as boot-stage forensics.
 - BusyBox `cp` has no `--sparse`; use plain `cp` + `truncate` for sparse test images.
 - Growing a partition while a sibling is mounted needs the **`BLKPG` ioctl**, not
   `partprobe` (which EBUSYs). `gptgrow` does BLKPG.
-- Dropbear has no sftp-server; push with `cat | ssh 'cat > f'` (or `scp -O`), verify
-  with a checksum.
+- Dropbear serves sftp: it execs the static OpenSSH `/usr/libexec/sftp-server` for the
+  `sftp` subsystem (2024.85 default `SFTPSERVER_PATH`), so `sftp`/`scp` work directly.
 - The repo shell is **fish**, which doesn't word-split variables — inline `ssh -o`
   options, never store them in a var.
 - The QEMU smoke test exercises generic userspace, not the vendor kernel or hardware.
@@ -83,8 +83,8 @@ superblock mount-counts, and `fbsplash` breadcrumbs as boot-stage forensics.
   ten supported images with per-target boot partitions, model identity and logos.
   Physical BaseOS validation beyond RG40XXV remains outstanding and must be recorded
   per model rather than inferred from successful image construction.
-- **Silence boot breadcrumbs / release vs dev image split** (serial getty + dropbear
-  are dev conveniences).
+- **Silence boot breadcrumbs / release vs dev image split** (serial getty, dropbear
+  SSH/sftp are dev conveniences).
 - **PortMaster** later: the kernel already has squashfs + loop + overlay built in;
   glibc 2.35 and an `/etc/os-release` identity remain to be decided.
 

--- a/overlay/etc/init.d/dev
+++ b/overlay/etc/init.d/dev
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Development conveniences, started by rcS in the background.
+# Development conveniences (SSH + SFTP), started by rcS in the background.
 # This file is only installed in dev-flavour images (build-rootfs.sh).
 
 # Persistent dropbear host keys on /data.

--- a/validate-on-device.sh
+++ b/validate-on-device.sh
@@ -52,6 +52,9 @@ chk "SD card mounted (/mnt/sdcard)"    "mountpoint -q /mnt/sdcard"
 chk "nextui.elf running"               "pidof nextui.elf"
 chk "keymon running"                   "pidof keymon.elf"
 
+echo "=== dev services ==="
+chk "sftp-server present + executable"  "test -x /usr/libexec/sftp-server"
+
 echo "=== resources ==="
 echo "  processes: $(ps | wc -l)"
 free | awk "/Mem:/ {printf \"  RAM used: %d/%d MB\n\", (\$2-\$7)/1024, \$2/1024}" 2>/dev/null || free


### PR DESCRIPTION
## What

A single developer convenience for dev-flavour images, alongside the existing dropbear SSH: **SFTP** via a static OpenSSH 10.4p1 `sftp-server` at `/usr/libexec/sftp-server`.

## Why / how

Dropbear 2024.85 already execs its compile-time default `SFTPSERVER_PATH` there, so **no dropbear rebuild** — just dropping the binary in place makes `sftp`/Forklift/scp work. Closes the "dropbear has no sftp-server, push with `cat|ssh`" gap noted in `docs/06`. The binary is built in `build-tools.sh` (pinned + SHA256-verified, static, no OpenSSL/zlib) and installed + closure-whitelisted in `build-rootfs.sh`.

## Boot-time impact

None: `sftp-server` runs only on client connect, execed per-session by dropbear. Nothing changes on the boot path.

## Testing

- `build-tools.sh` produces the aarch64 static binary; `build-rootfs.sh rg40xxv` passes ELF closure.
- `validate-on-device.sh` gains a dev-service check (`sftp-server` present + executable).
- Verified live on an rg40xxv: SFTP round-trip from a Mac via Forklift and via `scp`, matching checksums.

Docs 01/06 updated.

---

Split out of #2, which now covers only adb-over-USB.